### PR TITLE
Fix msg client

### DIFF
--- a/src/axc.c
+++ b/src/axc.c
@@ -234,6 +234,7 @@ void axc_bundle_destroy(axc_bundle * bundle_p) {
     axc_buf_free(bundle_p->signed_pre_key_public_serialized_p);
     axc_buf_free(bundle_p->signed_pre_key_signature_p);
     axc_buf_free(bundle_p->identity_key_public_serialized_p);
+    free(bundle_p);
   }
 }
 
@@ -414,6 +415,7 @@ void axc_context_destroy_all(axc_context * ctx_p) {
     axc_mutexes_destroy(ctx_p->mutexes_p);
 
     free(ctx_p->db_filename);
+    free(ctx_p);
   }
 }
 
@@ -1111,6 +1113,10 @@ int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address 
 
 
   do {
+    if (key_l_p) {
+      signal_protocol_key_helper_key_list_free(key_l_p);
+      key_l_p = NULL;
+    }
     ret_val = signal_protocol_key_helper_generate_pre_keys(&key_l_p, new_id, 1, ctx_p->axolotl_global_context_p);
     if (ret_val) {
       err_msg = "failed to generate a new key";
@@ -1158,7 +1164,7 @@ cleanup:
 
   SIGNAL_UNREF(pre_key_msg_p);
   SIGNAL_UNREF(session_record_p);
-  SIGNAL_UNREF(session_cipher_p);
+  session_cipher_free(session_cipher_p);
   session_builder_free(session_builder_p);
   signal_protocol_key_helper_key_list_free(key_l_p);
 

--- a/src/axc_crypto.c
+++ b/src/axc_crypto.c
@@ -383,6 +383,7 @@ cleanup:
     }
   }
 
+  free(pt_p);
   free(out_p);
   gcry_cipher_close(cipher_hd);
 

--- a/src/axc_store.c
+++ b/src/axc_store.c
@@ -757,6 +757,7 @@ int axc_db_pre_key_get_list(size_t amount, axc_context * axc_ctx_p, axc_buf_list
   }
 
   *list_head_pp = axc_buf_list_item_get_next(head_p);
+  axc_buf_list_item_set_next(head_p, NULL);
   ret_val = 0;
 
 cleanup:
@@ -764,8 +765,8 @@ cleanup:
     axc_buf_free(serialized_keypair_data_p);
     SIGNAL_UNREF(pre_key_p);
     axc_buf_free(pre_key_public_serialized_p);
-    axc_buf_list_free(head_p);
   }
+  axc_buf_list_free(head_p);
 
   db_conn_cleanup(db_p, pstmt_p, err_msg, __func__, axc_ctx_p);
   return ret_val;

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -155,30 +155,6 @@ int main(void) {
 
     axc_buf_free(msg_buf_p);
 
-#if 0
-    printf("creating handshake initiation message\n");
-    axc_handshake * handshake_a;
-    if (axc_handshake_initiate(&addr_b, ctx_a_p, &handshake_a)) {
-      fprintf(stderr, "failed to initialize handshake from alice to bob\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
-
-    printf("'sending' the message to bob and accepting it\n");
-    axc_handshake * handshake_b;
-    if (axc_handshake_accept(axc_handshake_get_data(handshake_a), &addr_a, ctx_b_p, &handshake_b)) {
-      fprintf(stderr, "failed to accept handshake on bob's side\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
-
-    printf("'sending' response from bob back to alice\n");
-    if (axc_handshake_acknowledge(axc_handshake_get_data(handshake_b), handshake_a, ctx_a_p)) {
-      fprintf(stderr, "failed to acknowledge handhshake on alice' side\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
-#endif
     printf("session created on each side\n");
   } else {
     printf("session exists.\n");

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -127,7 +127,6 @@ int main(void) {
       axc_cleanup(ctx_b_p);
       return EXIT_FAILURE;
     }
-
     addr_a.device_id = alice_id;
 
     axc_buf * pt_buf_p;
@@ -183,6 +182,13 @@ int main(void) {
     printf("session created on each side\n");
   } else {
     printf("session exists.\n");
+    uint32_t alice_id;
+    if (axc_get_device_id(ctx_a_p, &alice_id)) {
+      fprintf(stderr, "failed to retrieve alice's device_id\n");
+      axc_cleanup(ctx_b_p);
+      return EXIT_FAILURE;
+    }
+    addr_a.device_id = alice_id;
   }
   printf("now trying to ready to 'send' and 'receive' messages\n");
 

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -1,76 +1,55 @@
 #include <ctype.h> // toupper
 #include <stdio.h> // printf, getline
 #include <stdlib.h> // exit codes
-#include <sys/types.h> // socket
-#include <sys/socket.h> // socket
-#include <netdb.h> // getaddrinfo
 #include <string.h> // memset, strlen
-#include <unistd.h> // write
-
 
 #include "axc.h"
 
-#define PORT "5555"
+#define FAIL0(lbl,...) do { ret = EXIT_FAILURE; fprintf(stderr, __VA_ARGS__); goto lbl; } while (0)
+#define FAIL(...) FAIL0(cleanup,__VA_ARGS__)
 
 int main(void) {
   printf("sup\n");
   printf("initializing context for alice...\n");
   axc_context * ctx_a_p;
-  if (axc_context_create(&ctx_a_p)) {
-    fprintf(stderr, "failed to create axc context\n");
-    return EXIT_FAILURE;
-  }
+  int ret = EXIT_SUCCESS;
+  if (axc_context_create(&ctx_a_p))
+    FAIL0(cleanup_none, "failed to create axc context\n");
 
   axc_context_set_log_func(ctx_a_p, axc_default_log);
   axc_context_set_log_level(ctx_a_p, AXC_LOG_DEBUG);
 
   char * db_a_fn = "client/a.sqlite";
-  if (axc_context_set_db_fn(ctx_a_p, db_a_fn, strlen(db_a_fn))) {
-    fprintf(stderr, "failed to set db filename\n");
-    return EXIT_FAILURE;
-  }
+  if (axc_context_set_db_fn(ctx_a_p, db_a_fn, strlen(db_a_fn)))
+    FAIL0(cleanup_a, "failed to set db filename\n");
 
   printf("set db fn\n");
 
-  if (axc_init(ctx_a_p)) {
-    fprintf(stderr, "failed to init axc\n");
-    return EXIT_FAILURE;
-  }
+  if (axc_init(ctx_a_p))
+    FAIL0(cleanup_a, "failed to init axc\n");
 
   printf("installing client for alice...\n");
-  if (axc_install(ctx_a_p)) {
-    fprintf(stderr, "failed to install axc\n");
-    axc_cleanup(ctx_a_p);
-    return EXIT_FAILURE;
-  }
+  if (axc_install(ctx_a_p))
+    FAIL0(cleanup_a, "failed to install axc\n");
 
   printf("initializing context for bob...\n");
   axc_context * ctx_b_p;
-  if (axc_context_create(&ctx_b_p)) {
-    fprintf(stderr, "failed to create axc context\n");
-    return EXIT_FAILURE;
-  }
+  if (axc_context_create(&ctx_b_p))
+    FAIL0(cleanup_a, "failed to create axc context\n");
 
   char * db_b_fn = "client/b.sqlite";
-  if (axc_context_set_db_fn(ctx_b_p, db_b_fn, strlen(db_b_fn))) {
-    fprintf(stderr, "failed to set db filename\n");
-    return EXIT_FAILURE;
-  }
+  if (axc_context_set_db_fn(ctx_b_p, db_b_fn, strlen(db_b_fn)))
+    FAIL("failed to set db filename\n");
 
   axc_context_set_log_func(ctx_b_p, axc_default_log);
   axc_context_set_log_level(ctx_b_p, AXC_LOG_DEBUG);
 
-  if (axc_init(ctx_b_p)) {
-    fprintf(stderr, "failed to init axc\n");
-    return EXIT_FAILURE;
-  }
+  if (axc_init(ctx_b_p))
+    FAIL("failed to init axc\n");
 
   printf("installing client for bob...\n");
-  if (axc_install(ctx_b_p)) {
-    fprintf(stderr, "failed to install axc\n");
-    axc_cleanup(ctx_b_p);
-    return EXIT_FAILURE;
-  }
+  if (axc_install(ctx_b_p))
+    FAIL("failed to install axc\n");
 
   axc_address addr_a = {
       .name = "alice",
@@ -88,11 +67,8 @@ int main(void) {
   if (!axc_session_exists_initiated(&addr_b, ctx_a_p)) {
     printf("creating session between alice and bob\n");
     axc_bundle *bundle_bob;
-    if (axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob)) {
-      fprintf(stderr, "failed to collect bob's bundle\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob))
+      FAIL("failed to collect bob's bundle\n");
     // addr_b.device_id = axc_bundle_get_reg_id(bundle_bob);
     if (axc_session_from_bundle(axc_buf_list_item_get_id(axc_bundle_get_pre_key_list(bundle_bob)),
                                 axc_buf_list_item_get_buf(axc_bundle_get_pre_key_list(bundle_bob)),
@@ -101,69 +77,44 @@ int main(void) {
                                 axc_bundle_get_signature(bundle_bob),
                                 axc_bundle_get_identity_key(bundle_bob),
                                 &addr_b,
-                                ctx_a_p)) {
-      fprintf(stderr, "failed to create session from bob's bundle\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+                                ctx_a_p))
+      FAIL("failed to create session from bob's bundle\n");
     axc_bundle_destroy(bundle_bob);
     axc_buf * msg_buf_p = axc_buf_create((const uint8_t *)"hello", strlen("hello") + 1);
-    if (!msg_buf_p) {
-      fprintf(stderr, "failed to create 'hello' msg buffer\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (!msg_buf_p)
+      FAIL("failed to create 'hello' msg buffer\n");
 
     axc_buf * ct_buf_p;
-    if (axc_message_encrypt_and_serialize(msg_buf_p, &addr_b, ctx_a_p, &ct_buf_p)) {
-      fprintf(stderr, "failed to encrypt 'hello' message\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_message_encrypt_and_serialize(msg_buf_p, &addr_b, ctx_a_p, &ct_buf_p))
+      FAIL("failed to encrypt 'hello' message\n");
 
     uint32_t alice_id;
-    if (axc_get_device_id(ctx_a_p, &alice_id)) {
-      fprintf(stderr, "failed to retrieve alice's device_id\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_get_device_id(ctx_a_p, &alice_id))
+      FAIL("failed to retrieve alice's device_id\n");
     addr_a.device_id = alice_id;
 
     axc_buf * pt_buf_p;
-    if (axc_pre_key_message_process(ct_buf_p, &addr_a, ctx_b_p, &pt_buf_p)) {
-      fprintf(stderr, "failed to process 'hello' pre_key_message\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_pre_key_message_process(ct_buf_p, &addr_a, ctx_b_p, &pt_buf_p))
+      FAIL("failed to process 'hello' pre_key_message\n");
 
     axc_buf_free(ct_buf_p);
     axc_buf_free(pt_buf_p);
 
-    if (axc_message_encrypt_and_serialize(msg_buf_p, &addr_a, ctx_b_p, &ct_buf_p)) {
-      fprintf(stderr, "failed encrypting 2nd 'hello' message\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
-    if (axc_message_decrypt_from_serialized(ct_buf_p, &addr_b, ctx_a_p, &pt_buf_p)) {
-      fprintf(stderr, "failed decrypting 3rd 'hello' message\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_message_encrypt_and_serialize(msg_buf_p, &addr_a, ctx_b_p, &ct_buf_p))
+      FAIL("failed encrypting 2nd 'hello' message\n");
+    if (axc_message_decrypt_from_serialized(ct_buf_p, &addr_b, ctx_a_p, &pt_buf_p))
+      FAIL("failed decrypting 2nd 'hello' message\n");
 
     axc_buf_free(ct_buf_p);
     axc_buf_free(pt_buf_p);
-
     axc_buf_free(msg_buf_p);
 
     printf("session created on each side\n");
   } else {
     printf("session exists.\n");
     uint32_t alice_id;
-    if (axc_get_device_id(ctx_a_p, &alice_id)) {
-      fprintf(stderr, "failed to retrieve alice's device_id\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_get_device_id(ctx_a_p, &alice_id))
+      FAIL("failed to retrieve alice's device_id\n");
     addr_a.device_id = alice_id;
   }
   printf("now trying to ready to 'send' and 'receive' messages\n");
@@ -171,16 +122,12 @@ int main(void) {
   char * line = (void *) 0;
   size_t len = 0;
   printf("enter message: ");
-  //goto cleanup;
   while(getline(&line, &len, stdin) > 0) {
     axc_buf * ciphertext_p;
     {
     axc_buf * msg_p = axc_buf_create((uint8_t *) line, strlen(line) + 1);
-    if (axc_message_encrypt_and_serialize(msg_p, &addr_b, ctx_a_p, &ciphertext_p)) {
-      fprintf(stderr, "failed to encrypt message from alice to bob\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_message_encrypt_and_serialize(msg_p, &addr_b, ctx_a_p, &ciphertext_p))
+      FAIL("failed to encrypt message from alice to bob\n");
     printf("encrypted message from alice to bob: %s\n", line);
     axc_buf_free(msg_p);
     }
@@ -195,11 +142,8 @@ int main(void) {
 
     axc_buf * upper_buf;
     axc_buf * plaintext_p;
-    if (axc_message_decrypt_from_serialized(ciphertext_p, &addr_a, ctx_b_p, &plaintext_p)) {
-      fprintf(stderr, "failed to decrypt message from alice to bob\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_message_decrypt_from_serialized(ciphertext_p, &addr_a, ctx_b_p, &plaintext_p))
+      FAIL("failed to decrypt message from alice to bob\n");
     axc_buf_free(ciphertext_p);
 
     printf("decrypted message: %s\n", axc_buf_get_data(plaintext_p));
@@ -213,11 +157,8 @@ int main(void) {
     upper_buf = axc_buf_create((uint8_t *) upper, strlen(upper) + 1);
     axc_buf_free(plaintext_p);
 
-    if (axc_message_encrypt_and_serialize(upper_buf, &addr_a, ctx_b_p, &ciphertext_p)) {
-      fprintf(stderr, "failed to encrypt message from bob to alice\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_message_encrypt_and_serialize(upper_buf, &addr_a, ctx_b_p, &ciphertext_p))
+      FAIL("failed to encrypt message from bob to alice\n");
     axc_buf_free(upper_buf);
 
     buf = signal_buffer_data(ciphertext_p);
@@ -228,11 +169,8 @@ int main(void) {
     }
     printf("\n");
 
-    if (axc_message_decrypt_from_serialized(ciphertext_p, &addr_b, ctx_a_p, &plaintext_p)) {
-      fprintf(stderr, "failed to decrypt message from bob to alice\n");
-      axc_cleanup(ctx_b_p);
-      return EXIT_FAILURE;
-    }
+    if (axc_message_decrypt_from_serialized(ciphertext_p, &addr_b, ctx_a_p, &plaintext_p))
+      FAIL("failed to decrypt message from bob to alice\n");
     axc_buf_free(ciphertext_p);
 
     printf("received reply from bob: %s\n", axc_buf_get_data(plaintext_p));
@@ -243,6 +181,11 @@ int main(void) {
   free(line);
 
   printf("done, exiting.\n");
-  axc_cleanup(ctx_a_p);
+
+cleanup:
   axc_cleanup(ctx_b_p);
+cleanup_a:
+  axc_cleanup(ctx_a_p);
+cleanup_none:
+  return ret;
 }

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -107,7 +107,7 @@ int main(void) {
       return EXIT_FAILURE;
     }
     axc_bundle_destroy(bundle_bob);
-    axc_buf * msg_buf_p = axc_buf_create("hello", strlen("hello") + 1);
+    axc_buf * msg_buf_p = axc_buf_create((const uint8_t *)"hello", strlen("hello") + 1);
     if (!msg_buf_p) {
       fprintf(stderr, "failed to create 'hello' msg buffer\n");
       axc_cleanup(ctx_b_p);
@@ -222,7 +222,7 @@ int main(void) {
 
     printf("decrypted message: %s\n", axc_buf_get_data(plaintext_p));
 
-    char * upper = axc_buf_get_data(plaintext_p);
+    char * upper = (char *)axc_buf_get_data(plaintext_p);
     for (size_t i = 0; i < strlen(upper); i++) {
       upper[i] = toupper(upper[i]);
     }

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -196,7 +196,7 @@ int main(void) {
   size_t len = 0;
   printf("enter message: ");
   //goto cleanup;
-  while(getline(&line, &len, stdin)) {
+  while(getline(&line, &len, stdin) > 0) {
     axc_buf * ciphertext_p;
     {
     axc_buf * msg_p = axc_buf_create((uint8_t *) line, strlen(line) + 1);
@@ -266,7 +266,7 @@ int main(void) {
   }
   free(line);
 
-  printf("done, exiting.");
+  printf("done, exiting.\n");
   axc_cleanup(ctx_a_p);
   axc_cleanup(ctx_b_p);
 }


### PR DESCRIPTION
Hi,

this set of changes does the following:
- fix #5 by basically duplicating the session setup code from `test/test_client.c` https://github.com/gkdr/axc/blob/206bf43d3e602598db81a083913144ff7089c88d/test/test_client.c#L89 (https://github.com/gkdr/axc/commit/2cafb157a9f811d208bedd6ce480b3715bc93558, https://github.com/gkdr/axc/commit/4187e64892aacf13c1b0254a42eb0fb37594967c and https://github.com/gkdr/axc/commit/54e8c17a3a198d4a69b4d50b9d8fc01b943dc91a)
- fix various memory leaks in `src/message_client` (https://github.com/gkdr/axc/commit/2cafb157a9f811d208bedd6ce480b3715bc93558) ...
- ... as well as in the main library (https://github.com/gkdr/axc/commit/960429ce9e80f78a9f3c7ccae09fb9657b066243)
- simplify the `message_client`'s code (https://github.com/gkdr/axc/commit/c77b01c00edfcf66ef0b61ef9e6ecbe392eec3bd)
- fix running into an endless loop in `message_client` on EOF of `stdin` (https://github.com/gkdr/axc/commit/5e4abed1bed7c40a586198fa27021c8d45a19efe)

Especially regarding items 1 and 3 I am not completely certain that this is the intended use of the API `axc` provides. I am relatively new to the Signal protocol itself, however, the message client en- and decryption now works between Alice and Bob.

Wrt. to the memory fixes on the library side (item 3 above), my assumption was that the library functions allocate this memory and therefore should also free it in order for user-code to be agnostic to future changes in the internals.

Please check carefully. I'm happy to reorder / squash or make other changes to this set of patches. Thank you!