### PR TITLE
add copyright headers to apply correctly GPL license

### DIFF
--- a/src/axc.c
+++ b/src/axc.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #include <inttypes.h>
 #include <stdarg.h> // va_*
 #include <stdio.h> // printf, fprintf

--- a/src/axc.c
+++ b/src/axc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/src/axc.h
+++ b/src/axc.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #pragma once
 
 #include <stdint.h>

--- a/src/axc.h
+++ b/src/axc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/src/axc_crypto.c
+++ b/src/axc_crypto.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #include <stdint.h> // int types
 #include <stdio.h> // fprintf
 #include <stdlib.h> // malloc

--- a/src/axc_crypto.c
+++ b/src/axc_crypto.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/src/axc_crypto.h
+++ b/src/axc_crypto.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #pragma once
 
 #include <stdint.h>

--- a/src/axc_crypto.h
+++ b/src/axc_crypto.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/src/axc_store.c
+++ b/src/axc_store.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #include <stdint.h> // int types
 #include <stdio.h> // printf
 #include <stdlib.h> // exit

--- a/src/axc_store.c
+++ b/src/axc_store.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/src/axc_store.h
+++ b/src/axc_store.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #pragma once
 
 #include "signal_protocol.h"

--- a/src/axc_store.h
+++ b/src/axc_store.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #include <ctype.h> // toupper
 #include <stdio.h> // printf, getline
 #include <stdlib.h> // exit codes

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/test/test_client.c
+++ b/test/test_client.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/test/test_client.c
+++ b/test/test_client.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
+ * SPDX-License-Identifier: GPL-3.0
+ * Author: Richard Bayerle <riba@firemail.cc>
+ */
+
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Richard Bayerle <riba@firemail.cc>
- * SPDX-License-Identifier: GPL-3.0
+ * SPDX-License-Identifier: GPL-3.0-only
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 


### PR DESCRIPTION
Dear Richard,

This PR is adding copyright headers on the source files of the axc software.
This allows correct identification of the copyright holder (yourself) as well as clear statement of the license under which those files are released.

The axc software was rejected while being processed by the Debian's ftp-master team (reviewing legal matters for new software entering Debian) so this change would help to get axc library within Debian (and therefore, later on, other software as libomemo and purple-lurch).

If you are happy with the change it would be really great if you could release a minor release (ie: 0.3.3) so we can use it to update our packaging.

Thanks in advance,