### PR TITLE
Remove unused var pre_key_id 

### DIFF
--- a/src/axc.c
+++ b/src/axc.c
@@ -1071,7 +1071,6 @@ int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address 
 
   pre_key_signal_message * pre_key_msg_p = (void *) 0;
   uint32_t new_id = 0;
-  uint32_t pre_key_id = 0;
   session_cipher * session_cipher_p = (void *) 0;
   axc_buf * plaintext_p = (void *) 0;
   signal_protocol_key_helper_pre_key_list_node * key_l_p = (void *) 0;


### PR DESCRIPTION
Follow-up on #17, removing the pre_key_id via a dedicated PR.
This is an unused variable which trigger a warning on build time