### PR TITLE
Bugfix: Let axc_context_destroy_all() free ctx passed to it.

### DIFF
--- a/src/axc.c
+++ b/src/axc.c
@@ -420,6 +420,8 @@ void axc_context_destroy_all(axc_context * ctx_p) {
     axc_mutexes_destroy(ctx_p->mutexes_p);
 
     free(ctx_p->db_filename);
+
+    free(ctx_p);
   }
 }
 


### PR DESCRIPTION
The project is using axc (e.g. lurch) assumes axc_context_destroy_all()
will free the ctx passed to it, but axc_context_destroy_all() actually only
cleans up its members, without freeing itself, which will cause severe memory
leak.

Signed-off-by: HardenedVault <root@hardenedvault.net>