### PR TITLE
Add missing symlinks libaxc.so.$(VER_MAJ) and libaxc.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ install: $(BDIR)
 	install -d $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/pkgconfig/
 	install -m 644 $(BDIR)/libaxc.a  $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libaxc.a
 	install -m 644 $(BDIR)/libaxc.so $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libaxc.so.$(VERSION)
+	ln -s libaxc.so.$(VERSION) $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libaxc.so.$(VER_MAJ)
+	ln -s libaxc.so.$(VERSION) $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libaxc.so
 	install -m 644 $(BDIR)/libaxc.pc $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/pkgconfig/
 	install -d $(DESTDIR)/$(PREFIX)/include/axc/
 	install -m 644 $(SDIR)/axc.h $(DESTDIR)/$(PREFIX)/include/axc/


### PR DESCRIPTION
Hi!

I use this patch in Gentoo packaging of libaxc. My interest is to get this patch (or some form of this patch) applied upstream so that (1) others can get the patch out of the box and (2) my own patch count downstream in Gentoo goes back to zero, e.g. to reduce the risk of merge conflicts with the next upstream release…

What do you think about the patch?

Best

Sebastian

PS: This pull request has a sibling at https://github.com/gkdr/libomemo/pull/34