### PR TITLE
Use session_cipher_free() to release session_cipher object

### DIFF
--- a/src/axc.c
+++ b/src/axc.c
@@ -1140,7 +1140,7 @@ cleanup:
   }
 
   SIGNAL_UNREF(pre_key_msg_p);
-  SIGNAL_UNREF(session_cipher_p);
+  session_cipher_free(session_cipher_p);
   signal_protocol_key_helper_key_list_free(key_l_p);
 
   return ret_val;


### PR DESCRIPTION
Since session_cipher is not a reference-counting type derived from signal_type_base, its instances should not be released with the macro SIGNAL_UNREF(), otherwise a weird memory leak will happen.