### PR TITLE
Makefile: Fix possible race condition in test* targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,13 +144,13 @@ endif
 test_store: $(SDIR)/axc_store.c $(SDIR)/axc_crypto.c $(TDIR)/test_store.c
 	$(CC) $(TESTFLAGS) -o $(TDIR)/$@.o  $(TDIR)/test_store.c $(SDIR)/axc_crypto.c $(LDFLAGS_T)
 	-$(TDIR)/$@.o
-	mv *.g* $(TDIR)
+	find . -maxdepth 1 -iname 'test*.g*' -exec mv {} $(TDIR) \;
 
 .PHONY: test_client
 test_client: $(SDIR)/axc.c $(SDIR)/axc_crypto.c  $(SDIR)/axc_store.c $(TDIR)/test_client.c
 	$(CC) $(TESTFLAGS) -o $(TDIR)/$@.o $(SDIR)/axc_crypto.c $(TDIR)/test_client.c $(LDFLAGS_T)
 	-$(TDIR)/$@.o
-	mv *.g* $(TDIR)
+	find . -maxdepth 1 -iname 'test*.g*' -exec mv {} $(TDIR) \;
 
 .PHONY: coverage
 coverage: test


### PR DESCRIPTION
This is similar to https://github.com/gkdr/libomemo/pull/31

Such a race conidition has been detected and raised as a Debian bug which you can read about here (to see the logs, for instance): https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=983975

Thanks for all your work!