### PR TITLE
Fix cross-build from source faillure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ PKGCFG_L=$(GLIB_LDFLAGS) \
 	 $(LIBGCRYPT_LDFLAGS)
 
 REQPKG=libsignal-protocol-c
-REQPKG:=$(shell pkg-config --exists $(REQPKG) && echo '$(REQPKG)')
+REQPKG:=$(shell $(PKG_CONFIG) --exists $(REQPKG) && echo '$(REQPKG)')
 ifneq ($(REQPKG),)
 	PKGCFG_C += $(SIGNAL_CFLAGS)
 	PKGCFG_L += $(SIGNAL_LDFLAGS)


### PR DESCRIPTION
axc fails to cross build from source, because its upstream Makefile hard
codes the build architecture pkg-config in one occasion. It already uses
the standard substitution variable for every other case. Please consider
applying the attached patch to make it cross buildable.

This has been reported by Helmut Grohne at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=993455