### PR TITLE
Address "warning: struct has no members [-Wpedantic]" (fixes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ## [0.3.3] - 2020-07-23
 ### Added
-- Correct license headers. (thanks @henry-nicolas)
+- Correct license headers. (thanks [@henry-nicolas](https://github.com/henry-nicolas))
 - This file.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [x.x.x] - xxxx-xx-xx
+### Fixed
+- Compiler warnings ([#21](https://github.com/gkdr/axc/issues/21), [#29](https://github.com/gkdr/axc/pull/29)) (thanks, [@hartwork](https://github.com/hartwork)!)
+
 ## [0.3.6] - 2021-09-06
 ### Fixed
 - `pkg_config` can now be set from env like the rest of the tools. ([#28](https://github.com/gkdr/axc/pull/28)) (thanks, [@henry-nicolas](https://github.com/henry-nicolas) and Helmut Grohne!)

--- a/src/axc.c
+++ b/src/axc.c
@@ -36,6 +36,8 @@ typedef struct axc_mutexes {
   #ifndef NO_THREADS
   pthread_mutex_t * mutex_p;
   pthread_mutexattr_t * mutex_attr_p;
+  #else
+  int dummy; // to silence "warning: struct has no members [-Wpedantic]"
   #endif
 } axc_mutexes;
 


### PR DESCRIPTION
Fixes #21, if you like

## Before

```console
# make clean build/libaxc-nt.a
rm -f test/*.o
rm -f test/*.gcno test/*.gcda test/*.sqlite
cc -fPIC -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include    -I/usr/include/signal  -std=c11 -g -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -funsigned-char -fno-builtin-memset -fstack-protector-strong -Wformat -Werror=format-security -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE -D_DEFAULT_SOURCE -DNO_THREADS -c src/axc.c -o build/axc-nt.o
src/axc.c:35:16: warning: struct has no members [-Wpedantic]
   35 | typedef struct axc_mutexes {
      |                ^~~~~~~~~~~
cc -fPIC -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include    -I/usr/include/signal  -std=c11 -g -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -funsigned-char -fno-builtin-memset -fstack-protector-strong -Wformat -Werror=format-security -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE -D_DEFAULT_SOURCE -c src/axc_crypto.c -o build/axc_crypto.o
cc -fPIC -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include    -I/usr/include/signal  -std=c11 -g -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -funsigned-char -fno-builtin-memset -fstack-protector-strong -Wformat -Werror=format-security -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE -D_DEFAULT_SOURCE -c src/axc_store.c -o build/axc_store.o
ar rcs build/libaxc-nt.a build/axc-nt.o build/axc_crypto.o build/axc_store.o
```

## After

```console
# make clean build/libaxc-nt.a
rm -f test/*.o
rm -f test/*.gcno test/*.gcda test/*.sqlite
cc -fPIC -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include    -I/usr/include/signal  -std=c11 -g -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -funsigned-char -fno-builtin-memset -fstack-protector-strong -Wformat -Werror=format-security -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE -D_DEFAULT_SOURCE -DNO_THREADS -c src/axc.c -o build/axc-nt.o
cc -fPIC -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include    -I/usr/include/signal  -std=c11 -g -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -funsigned-char -fno-builtin-memset -fstack-protector-strong -Wformat -Werror=format-security -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE -D_DEFAULT_SOURCE -c src/axc_crypto.c -o build/axc_crypto.o
cc -fPIC -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include    -I/usr/include/signal  -std=c11 -g -Wall -Wextra -Wpedantic -Wstrict-overflow -fno-strict-aliasing -funsigned-char -fno-builtin-memset -fstack-protector-strong -Wformat -Werror=format-security -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE -D_DEFAULT_SOURCE -c src/axc_store.c -o build/axc_store.o
ar rcs build/libaxc-nt.a build/axc-nt.o build/axc_crypto.o build/axc_store.o
```