### PR TITLE
Fix another cross-build from source faillure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.7] - to be released
+### Fixed
+- `gcc` can now be set from env like the rest of the tools. ([#30](https://github.com/gkdr/axc/pull/30))) (thanks, [@henry-nicolas](https://github.com/henry-nicolas) and Helmut Grohne!)
+
 ## [0.3.6] - 2021-09-06
 ### Fixed
 - `pkg_config` can now be set from env like the rest of the tools. ([#28](https://github.com/gkdr/axc/pull/28)) (thanks, [@henry-nicolas](https://github.com/henry-nicolas) and Helmut Grohne!)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MKDIR = mkdir
 MKDIR_P = mkdir -p
 CMAKE ?= cmake
 CMAKE_FLAGS = -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-fPIC
-ARCH := $(shell gcc -print-multiarch)
+ARCH := $(shell $(CC) -print-multiarch)
 VER_MAJ = 0
 VERSION = 0.3.6
 


### PR DESCRIPTION
axc now cross builds successfully, but the resulting build is so broken
that we classify it as build failure. It uses build architecture
multiarch paths instead of host architecture ones. The reason is rooted
in gcc -print-multiarch, which prints the build architecture multiarch.
We need to use the host architecture multiarch there. Please consider
applying the attached patch.

This has been reported by Helmut Grohne at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=994671