### PR TITLE
Cover Linux build by GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the GPL v2 or later
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the GPL v2 or later
+
+name: Build for Linux
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 2 * * 5'  # Every Friday at 2am
+
+jobs:
+  checks:
+    name: Build for Linux (${{ matrix.libsignal }} libsignal)
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        libsignal: ['system', 'bundled']
+    steps:
+
+    - uses: actions/checkout@v2.4.0
+
+    - name: Install build dependencies (all but libsignal-protocol-c)
+      run: |-
+        set -x
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends -V \
+            gcovr \
+            libcmocka-dev \
+            libgcrypt20-dev \
+            libglib2.0-dev \
+            libsqlite3-dev
+
+    - name: Install build dependency libsignal-protocol-c
+      if: ${{ matrix.libsignal == 'system' }}
+      run: |-
+        sudo apt-get install --yes --no-install-recommends -V \
+            libsignal-protocol-c-dev
+
+    - name: Fetch Git submodule for build dependency libsignal-protocol-c
+      if: ${{ matrix.libsignal == 'bundled' }}
+      run: |-
+        git submodule update --init --recursive
+
+    - name: Build
+      run: |-
+        set -x
+        make -j $(nproc) all build/libaxc-nt.a
+
+    - name: Test
+      run: |-
+        make coverage  # includes tests
+
+    - name: Install
+      run: |-
+        set -x -o pipefail
+        make DESTDIR="${PWD}"/ROOT install
+        find ROOT/ -not -type d | sort | xargs ls -l
+
+    - name: Store coverage HTML report
+      uses: actions/upload-artifact@v2.3.1
+      with:
+        name: coverage_${{ matrix.libsignal }}
+        path: coverage/
+        if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Compiler warnings ([#21](https://github.com/gkdr/axc/issues/21), [#29](https://github.com/gkdr/axc/pull/29)) (thanks, [@hartwork](https://github.com/hartwork)!)
 - `gcc` can now be set from env like the rest of the tools. ([#30](https://github.com/gkdr/axc/pull/30))) (thanks, [@henry-nicolas](https://github.com/henry-nicolas) and Helmut Grohne!)
 - Fix the build for users without libsignal-protocol-c installed system-wide ([#31](https://github.com/gkdr/axc/pull/31)) (thanks, [@hartwork](https://github.com/hartwork)!)
+### Infrastructure
+- Cover Linux build by GitHub Actions CI ([#31](https://github.com/gkdr/axc/pull/31)) (thanks, [@hartwork](https://github.com/hartwork)!)
 
 ## [0.3.6] - 2021-09-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Compiler warnings ([#21](https://github.com/gkdr/axc/issues/21), [#29](https://github.com/gkdr/axc/pull/29)) (thanks, [@hartwork](https://github.com/hartwork)!)
 - `gcc` can now be set from env like the rest of the tools. ([#30](https://github.com/gkdr/axc/pull/30))) (thanks, [@henry-nicolas](https://github.com/henry-nicolas) and Helmut Grohne!)
+- Fix the build for users without libsignal-protocol-c installed system-wide ([#31](https://github.com/gkdr/axc/pull/31)) (thanks, [@hartwork](https://github.com/hartwork)!)
 
 ## [0.3.6] - 2021-09-06
 ### Fixed


### PR DESCRIPTION
Hi @gkdr,

here's a small PR with a small CI to notify us when things break on Linux, the most recent Ubuntu that GitHub Actions has (while avoiding moving target `ubuntu-latest`). It targets branch `dev`, runs every week (in addition to PRs and pushes) so that we'll get notified when the ground shifts below out feet. It also configures GitHub Dependabot to send PRs (like [this one](https://github.com/libexpat/libexpat/pull/517)) to us when action `actions/checkout@v2.4.0` has a more recent release in the future (also avoiding moving Git tag `v2`).

Before the PR is merged, expected behavior can already be seen over at https://github.com/hartwork/axc/runs/4846368005?check_suite_focus=true .

Looking forward to review, best, Sebastian