### PR TITLE
fix tests for windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,10 +56,10 @@ jobs:
         ninja -v -C build all
         cat build/libaxc.pc
 
-    - name: Test (KNOWN TO FAIL)
+    - name: Test 
       run: |-
         set -x
-        CTEST_OUTPUT_ON_FAILURE=1 ninja -C build test || true  # TODO fix tests
+        CTEST_OUTPUT_ON_FAILURE=1 ninja -C build test 
         # Note: msys2 does not come with a package for gcovr, yet(?)
         # ninja -C build coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [UNRELEASED]
 ### Added
-- Log warning if `sqlite3_close()` fails
+- Log warning if `sqlite3_close()` fails ([#38](https://github.com/gkdr/axc/pull/38))
 
 ### Fixed
 - Add missing field `Requires.private:` to auto-generated pkg-config file `libaxc.pc` ([#32](https://github.com/gkdr/axc/pull/32)) (thanks, [@hartwork](https://github.com/hartwork)!)
-- Tests on Windows CI
+- Tests on Windows CI ([#38](https://github.com/gkdr/axc/pull/38))
 
 ### Changed
 - Migrate build system from a Makefile to CMake ([#32](https://github.com/gkdr/axc/pull/32)) (thanks, [@hartwork](https://github.com/hartwork)!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 ## [UNRELEASED]
+### Added
+- Log warning if `sqlite3_close()` fails
+
 ### Fixed
 - Add missing field `Requires.private:` to auto-generated pkg-config file `libaxc.pc` ([#32](https://github.com/gkdr/axc/pull/32)) (thanks, [@hartwork](https://github.com/hartwork)!)
+- Tests on Windows CI
 
 ### Changed
 - Migrate build system from a Makefile to CMake ([#32](https://github.com/gkdr/axc/pull/32)) (thanks, [@hartwork](https://github.com/hartwork)!)

--- a/src/axc_store.c
+++ b/src/axc_store.c
@@ -68,8 +68,13 @@ static void db_conn_cleanup(sqlite3 * db_p, sqlite3_stmt * pstmt_p, const char *
     axc_log(ctx_p, AXC_LOG_ERROR, "%s: %s (sqlite err: %s)\n", func_name, err_msg, sqlite3_errmsg(db_p));
   }
 
+  // it does not matter whether the statement failed or not, so just ignore the return value
   (void) sqlite3_finalize(pstmt_p);
-  (void) sqlite3_close(db_p);
+
+  int ret_val = sqlite3_close(db_p);
+  if (ret_val) {
+    axc_log(ctx_p, AXC_LOG_WARNING, "%s: failed to close the db as it is not finalized\n", func_name);
+  }
 }
 
 /**

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -10,6 +10,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+#include <errno.h>
 #include <stdio.h> // remove
 #include <string.h> // strlen
 #include <unistd.h> // access
@@ -68,9 +69,14 @@ int db_teardown(void ** state) {
   db_p = (void *) 0;
   pstmt_p = (void *) 0;
 
-  remove(AXC_DB_DEFAULT_FN);
-  remove(db_filename);
+  if (remove(AXC_DB_DEFAULT_FN)) {
+    perror("failed to remove default db");
+  }
+  if (remove(db_filename)) {
+    perror("failed to remove test db");
+  }
 
+  // as the call to remove often fails intentionally as at least one of the two DVs does not exist, don't let cleanup fail the test
   return 0;
 }
 

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -21,6 +21,7 @@ sqlite3 * db_p;
 sqlite3_stmt * pstmt_p;
 
 char * db_filename = "test.sqlite";
+char * rand_db_filename = (void *) 0;
 axc_context * ctx_global_p;
 
 signal_protocol_address addr_alice_42 = {.name = "alice", .name_len = 5, .device_id = 42};
@@ -40,7 +41,7 @@ int db_setup_internal(void **state) {
   (void) state;
 
   int rand_int = g_random_int();
-  char * rand_db_filename = g_strdup_printf("test_%d.sqlite", rand_int);
+  rand_db_filename = g_strdup_printf("test_%d.sqlite", rand_int);
 
   ctx_global_p = (void *) 0;
   assert_int_equal(axc_context_create(&ctx_global_p), 0);
@@ -79,6 +80,7 @@ int db_teardown(void ** state) {
   db_p = (void *) 0;
   pstmt_p = (void *) 0;
 
+
   if (!access(AXC_DB_DEFAULT_FN, F_OK) && remove(AXC_DB_DEFAULT_FN)) {
     perror("failed to remove default db");
   }
@@ -87,6 +89,9 @@ int db_teardown(void ** state) {
   }
 
   axc_context_destroy_all(ctx_global_p);
+
+  g_free(rand_db_filename);
+  rand_db_filename = (void *) 0;
 
   // as the call to remove often fails intentionally as at least one of the two DVs does not exist, don't let cleanup fail the test
   return 0;

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -80,10 +80,10 @@ int db_teardown(void ** state) {
   db_p = (void *) 0;
   pstmt_p = (void *) 0;
 
-  if (remove(AXC_DB_DEFAULT_FN)) {
+  if (!access(AXC_DB_DEFAULT_FN, F_OK) && remove(AXC_DB_DEFAULT_FN)) {
     perror("failed to remove default db");
   }
-  if (remove(ctx_global_p->db_filename)) {
+  if (!access(ctx_global_p->db_filename, F_OK) && remove(ctx_global_p->db_filename)) {
     perror("failed to remove test db");
   }
 

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -40,9 +40,12 @@ const int id = 1337;
 int db_setup_internal(void **state) {
   (void) state;
 
+  int rand_int = g_random_int();
+  char * rand_db_filename = g_strdup_printf("test_%d.sqlite", rand_int);
+
   ctx_global_p = (void *) 0;
   assert_int_equal(axc_context_create(&ctx_global_p), 0);
-  assert_int_equal(axc_context_set_db_fn(ctx_global_p, db_filename, strlen(db_filename)), 0);
+  assert_int_equal(axc_context_set_db_fn(ctx_global_p, rand_db_filename, strlen(rand_db_filename)), 0);
 
   db_p = (void *) 0;
   pstmt_p = (void *) 0;
@@ -74,17 +77,17 @@ int db_teardown(void ** state) {
     fprintf(stderr, "failed to close not finalized db\n");
   }
 
-  axc_context_destroy_all(ctx_global_p);
-
   db_p = (void *) 0;
   pstmt_p = (void *) 0;
 
   if (remove(AXC_DB_DEFAULT_FN)) {
     perror("failed to remove default db");
   }
-  if (remove(db_filename)) {
+  if (remove(ctx_global_p->db_filename)) {
     perror("failed to remove test db");
   }
+
+  axc_context_destroy_all(ctx_global_p);
 
   // as the call to remove often fails intentionally as at least one of the two DVs does not exist, don't let cleanup fail the test
   return 0;
@@ -108,7 +111,7 @@ void test_db_conn_open_should_create_db(void **state) {
 
   assert_int_equal(db_conn_open(&db_p, &pstmt_p, "", ctx_global_p), 0);
   assert_int_not_equal(db_p, 0);
-  assert_int_equal(access(db_filename, F_OK), 0);
+  assert_int_equal(access(ctx_global_p->db_filename, F_OK), 0);
 }
 
 void test_db_conn_open_should_prepare_statement(void **state) {
@@ -537,7 +540,7 @@ void test_db_pre_key_store_list(void **state) {
 
   axc_context * ctx_p = (void *) 0;
   assert_int_equal(axc_context_create(&ctx_p), 0);
-  assert_int_equal(axc_context_set_db_fn(ctx_p, db_filename, strlen(db_filename)), 0);
+  assert_int_equal(axc_context_set_db_fn(ctx_p, ctx_global_p->db_filename, strlen(ctx_global_p->db_filename)), 0);
 
   assert_int_equal(axc_init(ctx_p), 0);
 
@@ -653,7 +656,7 @@ void test_db_identity_set_and_get_key_pair(void **state) {
 
   axc_context * ctx_p = (void *) 0;
   assert_int_equal(axc_context_create(&ctx_p), 0);
-  assert_int_equal(axc_context_set_db_fn(ctx_p, db_filename, strlen(db_filename)), 0);
+  assert_int_equal(axc_context_set_db_fn(ctx_p, ctx_global_p->db_filename, strlen(ctx_global_p->db_filename)), 0);
   assert_int_equal(axc_init(ctx_p), 0);
 
   ratchet_identity_key_pair * identity_key_pair_p = (void *) 0;

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -68,10 +68,10 @@ int db_teardown(void ** state) {
   if (ret_val) {
     fprintf(stderr, "failed to finalize statement, SQLite error code: %d\n", ret_val);
   }
-  
+
   ret_val = sqlite3_close(db_p);
   if (ret_val) {
-    fprintf(stderr, "failed to close not finalized db");
+    fprintf(stderr, "failed to close not finalized db\n");
   }
 
   axc_context_destroy_all(ctx_global_p);

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -80,7 +80,6 @@ int db_teardown(void ** state) {
   db_p = (void *) 0;
   pstmt_p = (void *) 0;
 
-
   if (!access(AXC_DB_DEFAULT_FN, F_OK) && remove(AXC_DB_DEFAULT_FN)) {
     perror("failed to remove default db");
   }

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -10,7 +10,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <errno.h>
 #include <stdio.h> // remove
 #include <string.h> // strlen
 #include <unistd.h> // access

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -62,8 +62,18 @@ int db_setup(void **state) {
 
 int db_teardown(void ** state) {
   (void) state;
-  sqlite3_finalize(pstmt_p);
-  sqlite3_close(db_p);
+  
+  int ret_val = 0;
+  ret_val = sqlite3_finalize(pstmt_p);
+  if (ret_val) {
+    fprintf(stderr, "failed to finalize statement, SQLite error code: %d\n", ret_val);
+  }
+  
+  ret_val = sqlite3_close(db_p);
+  if (ret_val) {
+    fprintf(stderr, "failed to close not finalized db");
+  }
+
   axc_context_destroy_all(ctx_global_p);
 
   db_p = (void *) 0;


### PR DESCRIPTION
on the github actions runner, tests would fail on windows because the test-db could not be cleaned up using `remove()`.
i believe i have excluded an actual code issue, and it is either an actual permissions issue on the windows runner, or a combination of `remove()` being much nicer on windows than on linux with some test setup issue like double-`sqlite3_close()`ing the file.

in any case, the workaround is to make each test have its own DB by appending a random suffix.
