### PR TITLE
Actions: Enforce empty diff against clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the GPL v2 or later
+
+name: Enforce clang-format
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 2 * * 5'  # Every Friday at 2am
+
+jobs:
+  clang-format:
+    name: Enforce clang-format
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3.0.0
+
+    - name: Add Clang/LLVM repositories
+      run: |-
+        set -x
+        source /etc/os-release
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-14 main"
+
+    - name: Install clang-format
+      run: |-
+        set -x
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends -V \
+            clang-format-14
+
+    - name: Apply clang-format
+      run: |-
+        CLANG_FORMAT=clang-format-14 ./apply-clang-format.sh
+
+    - name: Require empty diff
+      run: |-
+        git diff --exit-code  # non-zero exit code fails CI

--- a/apply-clang-format.sh
+++ b/apply-clang-format.sh
@@ -1,0 +1,36 @@
+#! /usr/bin/env bash
+# Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the GPL v2 or later
+
+set -e
+
+: ${CLANG_FORMAT:=clang-format}
+
+args=(
+    # Style option docs at https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+    --style='{
+        Language: Cpp,
+        BasedOnStyle: Google,
+
+        AlignConsecutiveMacros: Consecutive,
+        ColumnLimit: 120,
+        DerivePointerAlignment: False,
+        PointerAlignment: Middle,
+        SortIncludes: Never,
+    }'
+    --verbose
+    -i  # for in-place operation
+)
+
+if [[ $# -gt 0 ]]; then
+    args+=( "$@" )
+else
+    ifs_backup="${IFS}"
+    IFS=$'\n';
+    args+=( $(git ls-files -z '*.[ch]' | tr '\0' '\n') )
+    IFS="${ifs_backup}"
+fi
+
+set -x
+
+exec "${CLANG_FORMAT}" "${args[@]}"

--- a/src/axc.c
+++ b/src/axc.c
@@ -4,19 +4,17 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
 #include <inttypes.h>
-#include <stdarg.h> // va_*
-#include <stdio.h> // printf, fprintf
-#include <stdlib.h> // exit, malloc
-#include <string.h> // memset
+#include <stdarg.h>  // va_*
+#include <stdio.h>   // printf, fprintf
+#include <stdlib.h>  // exit, malloc
+#include <string.h>  // memset
 
 #ifndef NO_THREADS
-#include <pthread.h> // mutex stuff
+#include <pthread.h>  // mutex stuff
 #endif
 
 #include <glib.h>
-
 
 #include "signal_protocol.h"
 #include "key_helper.h"
@@ -33,21 +31,21 @@ void recursive_mutex_lock(void * user_data);
 void recursive_mutex_unlock(void * user_data);
 
 typedef struct axc_mutexes {
-  #ifndef NO_THREADS
+#ifndef NO_THREADS
   pthread_mutex_t * mutex_p;
   pthread_mutexattr_t * mutex_attr_p;
-  #else
-  int dummy; // to silence "warning: struct has no members [-Wpedantic]"
-  #endif
+#else
+  int dummy;  // to silence "warning: struct has no members [-Wpedantic]"
+#endif
 } axc_mutexes;
 
 struct axc_context {
-    signal_context * axolotl_global_context_p;
-    signal_protocol_store_context * axolotl_store_context_p;
-    axc_mutexes * mutexes_p;
-    char * db_filename;
-    void (*log_func)(int level, const char * message, size_t len, void * user_data);
-    int log_level;
+  signal_context * axolotl_global_context_p;
+  signal_protocol_store_context * axolotl_store_context_p;
+  axc_mutexes * mutexes_p;
+  char * db_filename;
+  void (*log_func)(int level, const char * message, size_t len, void * user_data);
+  int log_level;
 };
 
 struct axc_handshake {
@@ -88,25 +86,17 @@ int axc_buf_list_item_create(axc_buf_list_item ** item_pp, uint32_t * id_p, axc_
   return 0;
 }
 
-void axc_buf_list_item_set_next(axc_buf_list_item * item_p, axc_buf_list_item * next_p) {
-  item_p->next_p = next_p;
-}
+void axc_buf_list_item_set_next(axc_buf_list_item * item_p, axc_buf_list_item * next_p) { item_p->next_p = next_p; }
 
-axc_buf_list_item * axc_buf_list_item_get_next(axc_buf_list_item * item_p) {
-  return item_p->next_p;
-}
+axc_buf_list_item * axc_buf_list_item_get_next(axc_buf_list_item * item_p) { return item_p->next_p; }
 
-uint32_t axc_buf_list_item_get_id(axc_buf_list_item * item_p) {
-  return item_p->id;
-}
+uint32_t axc_buf_list_item_get_id(axc_buf_list_item * item_p) { return item_p->id; }
 
-axc_buf * axc_buf_list_item_get_buf(axc_buf_list_item * item_p) {
-  return item_p->buf_p;
-}
+axc_buf * axc_buf_list_item_get_buf(axc_buf_list_item * item_p) { return item_p->buf_p; }
 
 void axc_buf_list_free(axc_buf_list_item * head_p) {
   axc_buf_list_item * next = head_p;
-  axc_buf_list_item * temp = (void *) 0;
+  axc_buf_list_item * temp = (void *)0;
 
   while (next) {
     axc_buf_free(next->buf_p);
@@ -120,18 +110,18 @@ int axc_bundle_collect(size_t n, axc_context * ctx_p, axc_bundle ** bundle_pp) {
   int ret_val = 0;
   char * err_msg = "";
 
-  axc_bundle * bundle_p = (void *) 0;
+  axc_bundle * bundle_p = (void *)0;
   uint32_t reg_id = 0;
-  axc_buf_list_item * pre_key_list_p = (void *) 0;
-  uint32_t signed_prekey_id = 0; //FIXME: right now, only one is ever generated, this should be changed
-  session_signed_pre_key * signed_prekey_p = (void *) 0;
-  ec_key_pair * signed_prekey_pair_p = (void *) 0;
-  ec_public_key * signed_prekey_public_p = (void *) 0;
-  axc_buf * signed_prekey_public_data_p = (void *) 0;
-  axc_buf * signed_prekey_signature_data_p = (void *) 0;
-  ratchet_identity_key_pair * identity_key_pair_p = (void *) 0;
-  ec_public_key * identity_key_public_p = (void *) 0;
-  axc_buf * identity_key_public_data_p = (void *) 0;
+  axc_buf_list_item * pre_key_list_p = (void *)0;
+  uint32_t signed_prekey_id = 0;  // FIXME: right now, only one is ever generated, this should be changed
+  session_signed_pre_key * signed_prekey_p = (void *)0;
+  ec_key_pair * signed_prekey_pair_p = (void *)0;
+  ec_public_key * signed_prekey_public_p = (void *)0;
+  axc_buf * signed_prekey_public_data_p = (void *)0;
+  axc_buf * signed_prekey_signature_data_p = (void *)0;
+  ratchet_identity_key_pair * identity_key_pair_p = (void *)0;
+  ec_public_key * identity_key_public_p = (void *)0;
+  axc_buf * identity_key_public_data_p = (void *)0;
 
   axc_log(ctx_p, AXC_LOG_DEBUG, "%s: entered", __func__);
 
@@ -213,29 +203,17 @@ cleanup:
   return ret_val;
 }
 
-uint32_t axc_bundle_get_reg_id(axc_bundle * bundle_p) {
-  return bundle_p->registration_id;
-}
+uint32_t axc_bundle_get_reg_id(axc_bundle * bundle_p) { return bundle_p->registration_id; }
 
-axc_buf_list_item * axc_bundle_get_pre_key_list(axc_bundle * bundle_p) {
-  return bundle_p->pre_keys_head_p;
-}
+axc_buf_list_item * axc_bundle_get_pre_key_list(axc_bundle * bundle_p) { return bundle_p->pre_keys_head_p; }
 
-uint32_t axc_bundle_get_signed_pre_key_id(axc_bundle * bundle_p) {
-  return bundle_p->signed_pre_key_id;
-}
+uint32_t axc_bundle_get_signed_pre_key_id(axc_bundle * bundle_p) { return bundle_p->signed_pre_key_id; }
 
-axc_buf * axc_bundle_get_signed_pre_key(axc_bundle * bundle_p) {
-  return bundle_p->signed_pre_key_public_serialized_p;
-}
+axc_buf * axc_bundle_get_signed_pre_key(axc_bundle * bundle_p) { return bundle_p->signed_pre_key_public_serialized_p; }
 
-axc_buf * axc_bundle_get_signature(axc_bundle * bundle_p) {
-  return bundle_p->signed_pre_key_signature_p;
-}
+axc_buf * axc_bundle_get_signature(axc_bundle * bundle_p) { return bundle_p->signed_pre_key_signature_p; }
 
-axc_buf * axc_bundle_get_identity_key(axc_bundle * bundle_p) {
-  return bundle_p->identity_key_public_serialized_p;
-}
+axc_buf * axc_bundle_get_identity_key(axc_bundle * bundle_p) { return bundle_p->identity_key_public_serialized_p; }
 
 void axc_bundle_destroy(axc_bundle * bundle_p) {
   if (bundle_p) {
@@ -247,67 +225,67 @@ void axc_bundle_destroy(axc_bundle * bundle_p) {
   }
 }
 
-void axc_default_log(int level, const char *message, size_t len, void *user_data) {
-  (void) len;
+void axc_default_log(int level, const char * message, size_t len, void * user_data) {
+  (void)len;
 
-  axc_context * ctx_p = (axc_context *) user_data;
+  axc_context * ctx_p = (axc_context *)user_data;
 
   if (ctx_p->log_level >= AXC_LOG_ERROR) {
-    switch(level) {
-    case AXC_LOG_ERROR:
-      fprintf(stderr, "[AXC ERROR] %s\n", message);
-      break;
-    case AXC_LOG_WARNING:
-      if (ctx_p->log_level >= AXC_LOG_WARNING) {
-        fprintf(stderr, "[AXC WARNING] %s\n", message);
-      }
-      break;
-    case AXC_LOG_NOTICE:
-      if (ctx_p->log_level >= AXC_LOG_NOTICE) {
-        fprintf(stderr, "[AXC NOTICE] %s\n", message);
-      }
-      break;
-    case AXC_LOG_INFO:
-      if (ctx_p->log_level >= AXC_LOG_INFO) {
-        fprintf(stdout, "[AXC INFO] %s\n", message);
-      }
-      break;
-    case AXC_LOG_DEBUG:
-      if (ctx_p->log_level >= AXC_LOG_DEBUG) {
-        fprintf(stdout, "[AXC DEBUG] %s\n", message);
-      }
-      break;
-    default:
-      if (ctx_p->log_level > AXC_LOG_DEBUG) {
-        fprintf(stderr, "[AXC %d] %s\n", level, message);
-      }
-      break;
+    switch (level) {
+      case AXC_LOG_ERROR:
+        fprintf(stderr, "[AXC ERROR] %s\n", message);
+        break;
+      case AXC_LOG_WARNING:
+        if (ctx_p->log_level >= AXC_LOG_WARNING) {
+          fprintf(stderr, "[AXC WARNING] %s\n", message);
+        }
+        break;
+      case AXC_LOG_NOTICE:
+        if (ctx_p->log_level >= AXC_LOG_NOTICE) {
+          fprintf(stderr, "[AXC NOTICE] %s\n", message);
+        }
+        break;
+      case AXC_LOG_INFO:
+        if (ctx_p->log_level >= AXC_LOG_INFO) {
+          fprintf(stdout, "[AXC INFO] %s\n", message);
+        }
+        break;
+      case AXC_LOG_DEBUG:
+        if (ctx_p->log_level >= AXC_LOG_DEBUG) {
+          fprintf(stdout, "[AXC DEBUG] %s\n", message);
+        }
+        break;
+      default:
+        if (ctx_p->log_level > AXC_LOG_DEBUG) {
+          fprintf(stderr, "[AXC %d] %s\n", level, message);
+        }
+        break;
     }
   }
 }
 
 void axc_log(axc_context * ctx_p, int level, const char * format, ...) {
-  if(ctx_p->log_func) {
+  if (ctx_p->log_func) {
     va_list args;
     va_list args_cpy;
     va_copy(args_cpy, args);
 
     va_start(args, format);
-    size_t len = vsnprintf((void *) 0, 0, format, args) + 1;
+    size_t len = vsnprintf((void *)0, 0, format, args) + 1;
     va_end(args);
 
     char msg[len];
     va_start(args_cpy, format);
     size_t final_len = vsnprintf(msg, len, format, args_cpy);
     va_end(args_cpy);
-    if(final_len > 0) {
+    if (final_len > 0) {
       ctx_p->log_func(level, msg, len, ctx_p);
     }
   }
 }
 
 int axc_mutexes_create_and_init(axc_mutexes ** mutexes_pp) {
-  #ifndef NO_THREADS
+#ifndef NO_THREADS
   axc_mutexes * mutexes_p = malloc(sizeof(axc_mutexes));
   if (!mutexes_p) {
     return -1;
@@ -337,16 +315,15 @@ int axc_mutexes_create_and_init(axc_mutexes ** mutexes_pp) {
   if (pthread_mutex_init(mutex_p, mutex_attr_p)) {
     return -6;
   }
-  #else
-  *mutexes_pp = (void *) 0;
-  #endif
-
+#else
+  *mutexes_pp = (void *)0;
+#endif
 
   return 0;
 }
 
 void axc_mutexes_destroy(axc_mutexes * mutexes_p) {
-  #ifndef NO_THREADS
+#ifndef NO_THREADS
   if (mutexes_p) {
     if (mutexes_p->mutex_p) {
       pthread_mutex_destroy(mutexes_p->mutex_p);
@@ -360,9 +337,9 @@ void axc_mutexes_destroy(axc_mutexes * mutexes_p) {
 
     free(mutexes_p);
   }
-  #else
-  (void) mutexes_p;
-  #endif
+#else
+  (void)mutexes_p;
+#endif
 }
 
 int axc_context_create(axc_context ** ctx_pp) {
@@ -370,7 +347,7 @@ int axc_context_create(axc_context ** ctx_pp) {
     return -1;
   }
 
-  axc_context * ctx_p = (void *) 0;
+  axc_context * ctx_p = (void *)0;
   ctx_p = malloc(sizeof(axc_context));
   if (!ctx_p) {
     return -2;
@@ -401,20 +378,17 @@ char * axc_context_get_db_fn(axc_context * ctx_p) {
   }
 }
 
-void axc_context_set_log_func(axc_context * ctx_p, void (*log_func)(int level, const char * message, size_t len, void * user_data)) {
+void axc_context_set_log_func(axc_context * ctx_p,
+                              void (*log_func)(int level, const char * message, size_t len, void * user_data)) {
   ctx_p->log_func = log_func;
 }
 
-void axc_context_set_log_level(axc_context * ctx_p, int level) {
-  ctx_p->log_level = level;
-}
+void axc_context_set_log_level(axc_context * ctx_p, int level) { ctx_p->log_level = level; }
 
-int axc_context_get_log_level(axc_context * ctx_p) {
-  return ctx_p->log_level;
-}
+int axc_context_get_log_level(axc_context * ctx_p) { return ctx_p->log_level; }
 
 signal_context * axc_context_get_axolotl_ctx(axc_context * ctx_p) {
-  return ctx_p ? ctx_p->axolotl_global_context_p : (void *) 0;
+  return ctx_p ? ctx_p->axolotl_global_context_p : (void *)0;
 }
 
 void axc_context_destroy_all(axc_context * ctx_p) {
@@ -429,46 +403,38 @@ void axc_context_destroy_all(axc_context * ctx_p) {
 }
 
 void recursive_mutex_lock(void * user_data) {
-  #ifndef NO_THREADS
-  axc_context * ctx_p = (axc_context *) user_data;
+#ifndef NO_THREADS
+  axc_context * ctx_p = (axc_context *)user_data;
   pthread_mutex_lock(ctx_p->mutexes_p->mutex_p);
-  #else
-  (void) user_data;
-  #endif
+#else
+  (void)user_data;
+#endif
 }
 
 void recursive_mutex_unlock(void * user_data) {
-  #ifndef NO_THREADS
-  axc_context * ctx_p = (axc_context *) user_data;
+#ifndef NO_THREADS
+  axc_context * ctx_p = (axc_context *)user_data;
   pthread_mutex_unlock(ctx_p->mutexes_p->mutex_p);
-  #else
-  (void) user_data;
-  #endif
+#else
+  (void)user_data;
+#endif
 }
 
-axc_buf * axc_buf_create(const uint8_t * data, size_t len) {
-  return signal_buffer_create(data, len);
-}
+axc_buf * axc_buf_create(const uint8_t * data, size_t len) { return signal_buffer_create(data, len); }
 
-uint8_t * axc_buf_get_data(axc_buf * buf) {
-  return signal_buffer_data(buf);
-}
+uint8_t * axc_buf_get_data(axc_buf * buf) { return signal_buffer_data(buf); }
 
-size_t axc_buf_get_len(axc_buf * buf) {
-  return signal_buffer_len(buf);
-}
+size_t axc_buf_get_len(axc_buf * buf) { return signal_buffer_len(buf); }
 
-void axc_buf_free(axc_buf * buf) {
-  signal_buffer_bzero_free(buf);
-}
+void axc_buf_free(axc_buf * buf) { signal_buffer_bzero_free(buf); }
 
 int axc_init(axc_context * ctx_p) {
   axc_log(ctx_p, AXC_LOG_INFO, "%s: initializing axolotl client", __func__);
   char * err_msg = " ";
   int ret_val = 0;
 
-  axc_mutexes * mutexes_p = (void *) 0;
-  signal_protocol_store_context * store_context_p = (void *) 0;
+  axc_mutexes * mutexes_p = (void *)0;
+  signal_protocol_store_context * store_context_p = (void *)0;
 
   signal_protocol_session_store session_store = {
       .load_session_func = &axc_db_session_load,
@@ -478,32 +444,27 @@ int axc_init(axc_context * ctx_p) {
       .delete_session_func = &axc_db_session_delete,
       .delete_all_sessions_func = &axc_db_session_delete_all,
       .destroy_func = &axc_db_session_destroy_store_ctx,
-      .user_data = ctx_p
-  };
-  signal_protocol_pre_key_store pre_key_store = {
-      .load_pre_key = &axc_db_pre_key_load,
-      .store_pre_key = &axc_db_pre_key_store,
-      .contains_pre_key = &axc_db_pre_key_contains,
-      .remove_pre_key = &axc_db_pre_key_remove,
-      .destroy_func = &axc_db_pre_key_destroy_ctx,
-      .user_data = ctx_p
-  };
+      .user_data = ctx_p};
+  signal_protocol_pre_key_store pre_key_store = {.load_pre_key = &axc_db_pre_key_load,
+                                                 .store_pre_key = &axc_db_pre_key_store,
+                                                 .contains_pre_key = &axc_db_pre_key_contains,
+                                                 .remove_pre_key = &axc_db_pre_key_remove,
+                                                 .destroy_func = &axc_db_pre_key_destroy_ctx,
+                                                 .user_data = ctx_p};
   signal_protocol_signed_pre_key_store signed_pre_key_store = {
       .load_signed_pre_key = &axc_db_signed_pre_key_load,
       .store_signed_pre_key = &axc_db_signed_pre_key_store,
       .contains_signed_pre_key = &axc_db_signed_pre_key_contains,
       .remove_signed_pre_key = &axc_db_signed_pre_key_remove,
       .destroy_func = &axc_db_signed_pre_key_destroy_ctx,
-      .user_data = ctx_p
-  };
+      .user_data = ctx_p};
   signal_protocol_identity_key_store identity_key_store = {
       .get_identity_key_pair = &axc_db_identity_get_key_pair,
       .get_local_registration_id = &axc_db_identity_get_local_registration_id,
       .save_identity = &axc_db_identity_save,
       .is_trusted_identity = &axc_db_identity_always_trusted,
       .destroy_func = &axc_db_identity_destroy_ctx,
-      .user_data = ctx_p
-  };
+      .user_data = ctx_p};
 
   // init mutexes
   ret_val = axc_mutexes_create_and_init(&mutexes_p);
@@ -523,20 +484,18 @@ int axc_init(axc_context * ctx_p) {
   axc_log(ctx_p, AXC_LOG_DEBUG, "%s: created and set axolotl context", __func__);
 
   // 2. init and set crypto provider
-  signal_crypto_provider crypto_provider = {
-      .random_func = random_bytes,
-      .hmac_sha256_init_func = hmac_sha256_init,
-      .hmac_sha256_update_func = hmac_sha256_update,
-      .hmac_sha256_final_func = hmac_sha256_final,
-      .hmac_sha256_cleanup_func = hmac_sha256_cleanup,
-      .sha512_digest_init_func = sha512_digest_init,
-      .sha512_digest_update_func = sha512_digest_update,
-      .sha512_digest_final_func = sha512_digest_final,
-      .sha512_digest_cleanup_func = sha512_digest_cleanup,
-      .encrypt_func = aes_encrypt,
-      .decrypt_func = aes_decrypt,
-      .user_data = ctx_p
-  };
+  signal_crypto_provider crypto_provider = {.random_func = random_bytes,
+                                            .hmac_sha256_init_func = hmac_sha256_init,
+                                            .hmac_sha256_update_func = hmac_sha256_update,
+                                            .hmac_sha256_final_func = hmac_sha256_final,
+                                            .hmac_sha256_cleanup_func = hmac_sha256_cleanup,
+                                            .sha512_digest_init_func = sha512_digest_init,
+                                            .sha512_digest_update_func = sha512_digest_update,
+                                            .sha512_digest_final_func = sha512_digest_final,
+                                            .sha512_digest_cleanup_func = sha512_digest_cleanup,
+                                            .encrypt_func = aes_encrypt,
+                                            .decrypt_func = aes_decrypt,
+                                            .user_data = ctx_p};
   if (signal_context_set_crypto_provider(ctx_p->axolotl_global_context_p, &crypto_provider)) {
     err_msg = "failed to set crypto provider";
     ret_val = -1;
@@ -544,15 +503,16 @@ int axc_init(axc_context * ctx_p) {
   }
   axc_log(ctx_p, AXC_LOG_DEBUG, "%s: set axolotl crypto provider", __func__);
 
-  // 3. set locking functions
-  #ifndef NO_THREADS
-  if (signal_context_set_locking_functions(ctx_p->axolotl_global_context_p, recursive_mutex_lock, recursive_mutex_unlock)) {
+// 3. set locking functions
+#ifndef NO_THREADS
+  if (signal_context_set_locking_functions(ctx_p->axolotl_global_context_p, recursive_mutex_lock,
+                                           recursive_mutex_unlock)) {
     err_msg = "failed to set locking functions";
     ret_val = -1;
     goto cleanup;
   }
   axc_log(ctx_p, AXC_LOG_DEBUG, "%s: set locking functions", __func__);
-  #endif
+#endif
 
   // init store context
 
@@ -593,7 +553,7 @@ int axc_init(axc_context * ctx_p) {
 
 cleanup:
   if (ret_val < 0) {
-    //FIXME: this frees inited context, make this more fine-grained
+    // FIXME: this frees inited context, make this more fine-grained
     axc_cleanup(ctx_p);
     axc_log(ctx_p, AXC_LOG_ERROR, "%s: %s", __func__, err_msg);
   } else {
@@ -602,9 +562,7 @@ cleanup:
   return ret_val;
 }
 
-void axc_cleanup(axc_context * ctx_p) {
-  axc_context_destroy_all(ctx_p);
-}
+void axc_cleanup(axc_context * ctx_p) { axc_context_destroy_all(ctx_p); }
 
 int axc_install(axc_context * ctx_p) {
   char * err_msg = "";
@@ -612,16 +570,16 @@ int axc_install(axc_context * ctx_p) {
   int db_needs_init = 0;
 
   signal_context * global_context_p = ctx_p->axolotl_global_context_p;
-  ratchet_identity_key_pair * identity_key_pair_p = (void *) 0;
-  signal_protocol_key_helper_pre_key_list_node * pre_keys_head_p = (void *) 0;
-  session_signed_pre_key * signed_pre_key_p = (void *) 0;
-  signal_buffer * signed_pre_key_data_p = (void *) 0;
+  ratchet_identity_key_pair * identity_key_pair_p = (void *)0;
+  signal_protocol_key_helper_pre_key_list_node * pre_keys_head_p = (void *)0;
+  session_signed_pre_key * signed_pre_key_p = (void *)0;
+  signal_buffer * signed_pre_key_data_p = (void *)0;
   uint32_t registration_id;
 
   axc_log(ctx_p, AXC_LOG_INFO, "%s: calling install-time functions", __func__);
 
   ret_val = axc_db_create(ctx_p);
-  if (ret_val){
+  if (ret_val) {
     err_msg = "failed to create db";
     goto cleanup;
   }
@@ -661,7 +619,7 @@ int axc_install(axc_context * ctx_p) {
   }
 
   if (db_needs_reset) {
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db needs reset", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db needs reset", __func__);
     ret_val = axc_db_destroy(ctx_p);
     if (ret_val) {
       err_msg = "failed to reset db";
@@ -674,12 +632,13 @@ int axc_install(axc_context * ctx_p) {
       goto cleanup;
     }
   } else {
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db does not need reset", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db does not need reset", __func__);
   }
 
   if (db_needs_init) {
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db needs init", __func__ );
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: setting init status to AXC_DB_NEEDS_ROLLBACK (%i)", __func__, AXC_DB_NEEDS_ROLLBACK );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db needs init", __func__);
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: setting init status to AXC_DB_NEEDS_ROLLBACK (%i)", __func__,
+            AXC_DB_NEEDS_ROLLBACK);
 
     ret_val = axc_db_init_status_set(AXC_DB_NEEDS_ROLLBACK, ctx_p);
     if (ret_val) {
@@ -692,7 +651,7 @@ int axc_install(axc_context * ctx_p) {
       err_msg = "failed to generate the identity key pair";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: generated identity key pair", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: generated identity key pair", __func__);
 
     ret_val = signal_protocol_key_helper_generate_registration_id(&registration_id, 1, global_context_p);
     if (ret_val) {
@@ -702,40 +661,40 @@ int axc_install(axc_context * ctx_p) {
     axc_log(ctx_p, AXC_LOG_DEBUG, "%s: generated registration id: %i", __func__, registration_id);
 
     ret_val = signal_protocol_key_helper_generate_pre_keys(&pre_keys_head_p, 1, AXC_PRE_KEYS_AMOUNT, global_context_p);
-    if(ret_val) {
+    if (ret_val) {
       err_msg = "failed to generate pre keys";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: generated pre keys", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: generated pre keys", __func__);
 
-    ret_val = signal_protocol_key_helper_generate_signed_pre_key(&signed_pre_key_p, identity_key_pair_p, 0, g_get_real_time(), global_context_p);
+    ret_val = signal_protocol_key_helper_generate_signed_pre_key(&signed_pre_key_p, identity_key_pair_p, 0,
+                                                                 g_get_real_time(), global_context_p);
     if (ret_val) {
       err_msg = "failed to generate signed pre key";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: generated signed pre key", __func__ );
-
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: generated signed pre key", __func__);
 
     ret_val = axc_db_identity_set_key_pair(identity_key_pair_p, ctx_p);
     if (ret_val) {
       err_msg = "failed to set identity key pair";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved identity key pair", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved identity key pair", __func__);
 
     ret_val = axc_db_identity_set_local_registration_id(registration_id, ctx_p);
     if (ret_val) {
       err_msg = "failed to set registration id";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved registration id", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved registration id", __func__);
 
     ret_val = axc_db_pre_key_store_list(pre_keys_head_p, ctx_p);
     if (ret_val) {
       err_msg = "failed to save pre key list";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved pre keys", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved pre keys", __func__);
 
     ret_val = session_signed_pre_key_serialize(&signed_pre_key_data_p, signed_pre_key_p);
     if (ret_val) {
@@ -743,22 +702,24 @@ int axc_install(axc_context * ctx_p) {
       goto cleanup;
     }
 
-    ret_val = axc_db_signed_pre_key_store(session_signed_pre_key_get_id(signed_pre_key_p), signal_buffer_data(signed_pre_key_data_p), signal_buffer_len(signed_pre_key_data_p), ctx_p);
+    ret_val = axc_db_signed_pre_key_store(session_signed_pre_key_get_id(signed_pre_key_p),
+                                          signal_buffer_data(signed_pre_key_data_p),
+                                          signal_buffer_len(signed_pre_key_data_p), ctx_p);
     if (ret_val) {
       err_msg = "failed to save signed pre key";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved signed pre key", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: saved signed pre key", __func__);
 
     ret_val = axc_db_init_status_set(AXC_DB_INITIALIZED, ctx_p);
     if (ret_val) {
       err_msg = "failed to set init status to AXC_DB_INITIALIZED";
       goto cleanup;
     }
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: initialised DB", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: initialised DB", __func__);
 
   } else {
-    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db already initialized", __func__ );
+    axc_log(ctx_p, AXC_LOG_DEBUG, "%s: db already initialized", __func__);
   }
 
 cleanup:
@@ -780,14 +741,15 @@ int axc_get_device_id(axc_context * ctx_p, uint32_t * id_p) {
   return signal_protocol_identity_get_local_registration_id(ctx_p->axolotl_store_context_p, id_p);
 }
 
-int axc_message_encrypt_and_serialize(axc_buf * msg_p, const axc_address * recipient_addr_p, axc_context * ctx_p, axc_buf ** ciphertext_pp) {
+int axc_message_encrypt_and_serialize(axc_buf * msg_p, const axc_address * recipient_addr_p, axc_context * ctx_p,
+                                      axc_buf ** ciphertext_pp) {
   char * err_msg = "";
   int ret_val = 0;
 
-  session_cipher * cipher_p = (void *) 0;
-  ciphertext_message * cipher_msg_p = (void *) 0;
-  signal_buffer * cipher_msg_data_p = (void *) 0;
-  axc_buf * cipher_msg_data_cpy_p = (void *) 0;
+  session_cipher * cipher_p = (void *)0;
+  ciphertext_message * cipher_msg_p = (void *)0;
+  signal_buffer * cipher_msg_data_p = (void *)0;
+  axc_buf * cipher_msg_data_cpy_p = (void *)0;
 
   if (!ctx_p) {
     fprintf(stderr, "%s: axc ctx is null!\n", __func__);
@@ -810,8 +772,8 @@ int axc_message_encrypt_and_serialize(axc_buf * msg_p, const axc_address * recip
     goto cleanup;
   }
 
-
-  ret_val = session_cipher_create(&cipher_p, ctx_p->axolotl_store_context_p, recipient_addr_p, ctx_p->axolotl_global_context_p);
+  ret_val = session_cipher_create(&cipher_p, ctx_p->axolotl_store_context_p, recipient_addr_p,
+                                  ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to create session cipher";
     goto cleanup;
@@ -846,16 +808,17 @@ cleanup:
   return ret_val;
 }
 
-int axc_message_decrypt_from_serialized (axc_buf * msg_p, axc_address * sender_addr_p, axc_context * ctx_p, axc_buf ** plaintext_pp) {
+int axc_message_decrypt_from_serialized(axc_buf * msg_p, axc_address * sender_addr_p, axc_context * ctx_p,
+                                        axc_buf ** plaintext_pp) {
   char * err_msg = "";
   int ret_val = 0;
 
-  //TODO: add session_cipher_set_decryption_callback maybe?
-  //FIXME: check message type
+  // TODO: add session_cipher_set_decryption_callback maybe?
+  // FIXME: check message type
 
-  signal_message * ciphertext_p = (void *) 0;
-  session_cipher * cipher_p = (void *) 0;
-  axc_buf * plaintext_buf_p = (void *) 0;
+  signal_message * ciphertext_p = (void *)0;
+  session_cipher * cipher_p = (void *)0;
+  axc_buf * plaintext_buf_p = (void *)0;
 
   if (!ctx_p) {
     fprintf(stderr, "%s: axc ctx is null!\n", __func__);
@@ -878,18 +841,20 @@ int axc_message_decrypt_from_serialized (axc_buf * msg_p, axc_address * sender_a
     goto cleanup;
   }
 
-  ret_val = session_cipher_create(&cipher_p, ctx_p->axolotl_store_context_p, sender_addr_p, ctx_p->axolotl_global_context_p);
+  ret_val =
+      session_cipher_create(&cipher_p, ctx_p->axolotl_store_context_p, sender_addr_p, ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to create session cipher";
     goto cleanup;
   }
 
-  ret_val = signal_message_deserialize(&ciphertext_p, axc_buf_get_data(msg_p), axc_buf_get_len(msg_p), ctx_p->axolotl_global_context_p);
+  ret_val = signal_message_deserialize(&ciphertext_p, axc_buf_get_data(msg_p), axc_buf_get_len(msg_p),
+                                       ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to deserialize whisper msg";
     goto cleanup;
   }
-  ret_val = session_cipher_decrypt_signal_message(cipher_p, ciphertext_p, (void *) 0, &plaintext_buf_p);
+  ret_val = session_cipher_decrypt_signal_message(cipher_p, ciphertext_p, (void *)0, &plaintext_buf_p);
   if (ret_val) {
     err_msg = "failed to decrypt cipher message";
     goto cleanup;
@@ -912,18 +877,18 @@ int axc_session_exists_initiated(const axc_address * addr_p, axc_context * ctx_p
   int ret_val = 0;
   char * err_msg = "";
 
-  session_record * session_record_p = (void *) 0;
-  session_state * session_state_p = (void *) 0;
+  session_record * session_record_p = (void *)0;
+  session_state * session_state_p = (void *)0;
 
-  //TODO: if there was no response yet, even though it is an established session it keeps sending prekeymsgs
-  //      maybe that is "uninitiated" too?
+  // TODO: if there was no response yet, even though it is an established session it keeps sending prekeymsgs
+  //       maybe that is "uninitiated" too?
 
-  if(!signal_protocol_session_contains_session(ctx_p->axolotl_store_context_p, addr_p)) {
+  if (!signal_protocol_session_contains_session(ctx_p->axolotl_store_context_p, addr_p)) {
     return 0;
   }
 
   ret_val = signal_protocol_session_load_session(ctx_p->axolotl_store_context_p, &session_record_p, addr_p);
-  if (ret_val){
+  if (ret_val) {
     err_msg = "database error when trying to retrieve session";
     goto cleanup;
   } else {
@@ -956,9 +921,10 @@ cleanup:
 int axc_session_exists_any(const char * name, axc_context * ctx_p) {
   int ret_val = 0;
 
-  signal_int_list * sess_l_p = (void *) 0;
+  signal_int_list * sess_l_p = (void *)0;
 
-  ret_val = signal_protocol_session_get_sub_device_sessions(ctx_p->axolotl_store_context_p, &sess_l_p, name, strlen(name));
+  ret_val =
+      signal_protocol_session_get_sub_device_sessions(ctx_p->axolotl_store_context_p, &sess_l_p, name, strlen(name));
   if (ret_val < 0) {
     goto cleanup;
   }
@@ -970,69 +936,52 @@ cleanup:
   return ret_val;
 }
 
-
-int axc_session_from_bundle(uint32_t pre_key_id,
-                            axc_buf * pre_key_public_serialized_p,
-                            uint32_t signed_pre_key_id,
-                            axc_buf * signed_pre_key_public_serialized_p,
-                            axc_buf * signed_pre_key_signature_p,
-                            axc_buf * identity_key_public_serialized_p,
-                            const axc_address * remote_address_p,
+int axc_session_from_bundle(uint32_t pre_key_id, axc_buf * pre_key_public_serialized_p, uint32_t signed_pre_key_id,
+                            axc_buf * signed_pre_key_public_serialized_p, axc_buf * signed_pre_key_signature_p,
+                            axc_buf * identity_key_public_serialized_p, const axc_address * remote_address_p,
                             axc_context * ctx_p) {
-
   char * err_msg = "";
   int ret_val = 0;
 
-  ec_public_key * pre_key_public_p = (void *) 0;
-  ec_public_key * signed_pre_key_public_p = (void *) 0;
-  ec_public_key * identity_key_public_p = (void *) 0;
-  session_pre_key_bundle * bundle_p = (void *) 0;
-  session_builder * session_builder_p = (void *) 0;
+  ec_public_key * pre_key_public_p = (void *)0;
+  ec_public_key * signed_pre_key_public_p = (void *)0;
+  ec_public_key * identity_key_public_p = (void *)0;
+  session_pre_key_bundle * bundle_p = (void *)0;
+  session_builder * session_builder_p = (void *)0;
 
-  ret_val = curve_decode_point(&pre_key_public_p,
-                               axc_buf_get_data(pre_key_public_serialized_p),
-                               axc_buf_get_len(pre_key_public_serialized_p),
-                               ctx_p->axolotl_global_context_p);
+  ret_val = curve_decode_point(&pre_key_public_p, axc_buf_get_data(pre_key_public_serialized_p),
+                               axc_buf_get_len(pre_key_public_serialized_p), ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to deserialize public pre key";
     goto cleanup;
   }
 
-
-  ret_val = curve_decode_point(&signed_pre_key_public_p,
-                               axc_buf_get_data(signed_pre_key_public_serialized_p),
-                               axc_buf_get_len(signed_pre_key_public_serialized_p),
-                               ctx_p->axolotl_global_context_p);
+  ret_val = curve_decode_point(&signed_pre_key_public_p, axc_buf_get_data(signed_pre_key_public_serialized_p),
+                               axc_buf_get_len(signed_pre_key_public_serialized_p), ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to deserialize signed public pre key";
     goto cleanup;
   }
 
-  ret_val = curve_decode_point(&identity_key_public_p,
-                               axc_buf_get_data(identity_key_public_serialized_p),
-                               axc_buf_get_len(identity_key_public_serialized_p),
-                               ctx_p->axolotl_global_context_p);
+  ret_val = curve_decode_point(&identity_key_public_p, axc_buf_get_data(identity_key_public_serialized_p),
+                               axc_buf_get_len(identity_key_public_serialized_p), ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to deserialize public identity key";
     goto cleanup;
   }
 
-  ret_val = session_pre_key_bundle_create(&bundle_p,
-                                          remote_address_p->device_id,
-                                          remote_address_p->device_id, // this value is ignored
-                                          pre_key_id,
-                                          pre_key_public_p,
-                                          signed_pre_key_id,
-                                          signed_pre_key_public_p,
+  ret_val = session_pre_key_bundle_create(&bundle_p, remote_address_p->device_id,
+                                          remote_address_p->device_id,  // this value is ignored
+                                          pre_key_id, pre_key_public_p, signed_pre_key_id, signed_pre_key_public_p,
                                           axc_buf_get_data(signed_pre_key_signature_p),
-                                          axc_buf_get_len(signed_pre_key_signature_p),
-                                          identity_key_public_p);
+                                          axc_buf_get_len(signed_pre_key_signature_p), identity_key_public_p);
   if (ret_val) {
     err_msg = "failed to assemble bundle";
     goto cleanup;
   }
 
-  ret_val = session_builder_create(&session_builder_p, ctx_p->axolotl_store_context_p, remote_address_p, ctx_p->axolotl_global_context_p);
+  ret_val = session_builder_create(&session_builder_p, ctx_p->axolotl_store_context_p, remote_address_p,
+                                   ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to create session builder";
     goto cleanup;
@@ -1070,20 +1019,20 @@ int axc_session_delete(const char * user, uint32_t device_id, axc_context * ctx_
   return ret_val;
 }
 
-int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address * remote_address_p, axc_context * ctx_p, axc_buf ** plaintext_pp) {
+int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address * remote_address_p, axc_context * ctx_p,
+                                axc_buf ** plaintext_pp) {
   char * err_msg = "";
   int ret_val = 0;
 
-  pre_key_signal_message * pre_key_msg_p = (void *) 0;
+  pre_key_signal_message * pre_key_msg_p = (void *)0;
   uint32_t new_id = 0;
-  session_cipher * session_cipher_p = (void *) 0;
-  axc_buf * plaintext_p = (void *) 0;
-  signal_protocol_key_helper_pre_key_list_node * key_l_p = (void *) 0;
+  session_cipher * session_cipher_p = (void *)0;
+  axc_buf * plaintext_p = (void *)0;
+  signal_protocol_key_helper_pre_key_list_node * key_l_p = (void *)0;
 
-  ret_val = pre_key_signal_message_deserialize(&pre_key_msg_p,
-                                                axc_buf_get_data(pre_key_msg_serialized_p),
-                                                axc_buf_get_len(pre_key_msg_serialized_p),
-                                                ctx_p->axolotl_global_context_p);
+  ret_val =
+      pre_key_signal_message_deserialize(&pre_key_msg_p, axc_buf_get_data(pre_key_msg_serialized_p),
+                                         axc_buf_get_len(pre_key_msg_serialized_p), ctx_p->axolotl_global_context_p);
   if (ret_val == SG_ERR_INVALID_PROTO_BUF) {
     err_msg = "not a pre key msg";
     ret_val = AXC_ERR_NOT_A_PREKEY_MSG;
@@ -1102,7 +1051,6 @@ int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address 
     goto cleanup;
   }
 
-
   do {
     if (key_l_p) {
       signal_protocol_key_helper_key_list_free(key_l_p);
@@ -1116,23 +1064,25 @@ int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address 
 
     new_id++;
 
-  } while (signal_protocol_pre_key_contains_key(ctx_p->axolotl_store_context_p, session_pre_key_get_id(signal_protocol_key_helper_key_list_element(key_l_p))));
+  } while (signal_protocol_pre_key_contains_key(
+      ctx_p->axolotl_store_context_p, session_pre_key_get_id(signal_protocol_key_helper_key_list_element(key_l_p))));
 
-
-  ret_val = session_cipher_create(&session_cipher_p, ctx_p->axolotl_store_context_p, remote_address_p, ctx_p->axolotl_global_context_p);
+  ret_val = session_cipher_create(&session_cipher_p, ctx_p->axolotl_store_context_p, remote_address_p,
+                                  ctx_p->axolotl_global_context_p);
   if (ret_val) {
     err_msg = "failed to create session cipher";
     goto cleanup;
   }
 
-  //FIXME: find a way to retain the key (for MAM catchup)
-  ret_val = session_cipher_decrypt_pre_key_signal_message(session_cipher_p, pre_key_msg_p, (void *) 0, &plaintext_p);
+  // FIXME: find a way to retain the key (for MAM catchup)
+  ret_val = session_cipher_decrypt_pre_key_signal_message(session_cipher_p, pre_key_msg_p, (void *)0, &plaintext_p);
   if (ret_val) {
     err_msg = "failed to decrypt message";
     goto cleanup;
   }
 
-  ret_val = signal_protocol_pre_key_store_key(ctx_p->axolotl_store_context_p, signal_protocol_key_helper_key_list_element(key_l_p));
+  ret_val = signal_protocol_pre_key_store_key(ctx_p->axolotl_store_context_p,
+                                              signal_protocol_key_helper_key_list_element(key_l_p));
   if (ret_val) {
     err_msg = "failed to store new key";
     goto cleanup;
@@ -1156,8 +1106,8 @@ int axc_key_load_public_own(axc_context * ctx_p, axc_buf ** pubkey_data_pp) {
   char * err_msg = "";
   int ret_val = 0;
 
-  ratchet_identity_key_pair * kp_p = (void *) 0;
-  axc_buf * key_data_p = (void *) 0;
+  ratchet_identity_key_pair * kp_p = (void *)0;
+  axc_buf * key_data_p = (void *)0;
 
   ret_val = signal_protocol_identity_get_key_pair(ctx_p->axolotl_store_context_p, &kp_p);
   if (ret_val) {
@@ -1188,9 +1138,9 @@ int axc_key_load_public_addr(const char * name, uint32_t device_id, axc_context 
   char * err_msg = "";
   int ret_val = 0;
 
-  session_record * sr_p = (void *) 0;
-  ec_public_key * pubkey_p = (void *) 0;
-  axc_buf * key_data_p = (void *) 0;
+  session_record * sr_p = (void *)0;
+  ec_public_key * pubkey_p = (void *)0;
+  axc_buf * key_data_p = (void *)0;
   axc_address addr = {.name = name, .name_len = strlen(name), .device_id = device_id};
 
   ret_val = signal_protocol_session_load_session(ctx_p->axolotl_store_context_p, &sr_p, &addr);

--- a/src/axc.h
+++ b/src/axc.h
@@ -4,7 +4,6 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
 #pragma once
 
 #include <stdint.h>
@@ -29,7 +28,7 @@ typedef signal_protocol_address axc_address;
 #define AXC_ERR_NOT_A_PREKEY_MSG -10100
 #define AXC_ERR_INVALID_KEY_ID   -10200
 
-#define AXC_DB_DEFAULT_FN "axc.sqlite"
+#define AXC_DB_DEFAULT_FN   "axc.sqlite"
 #define AXC_PRE_KEYS_AMOUNT 100
 
 /**
@@ -59,14 +58,15 @@ int axc_context_set_db_fn(axc_context * ctx_p, char * filename, size_t fn_len);
  */
 char * axc_context_get_db_fn(axc_context * ctx_p);
 
-void axc_context_set_log_func(axc_context * ctx_p, void (*log_func)(int level, const char * message, size_t len, void * user_data));
+void axc_context_set_log_func(axc_context * ctx_p,
+                              void (*log_func)(int level, const char * message, size_t len, void * user_data));
 void axc_context_set_log_level(axc_context * ctx_p, int level);
 int axc_context_get_log_level(axc_context * ctx_p);
 
 void axc_context_destroy_all(axc_context * ctx_p);
 signal_context * axc_context_get_axolotl_ctx(axc_context * ctx_p);
 
-void axc_default_log(int level, const char *message, size_t len, void *user_data);
+void axc_default_log(int level, const char * message, size_t len, void * user_data);
 void axc_log(axc_context * ctx_p, int level, const char * format, ...);
 
 int axc_buf_list_item_create(axc_buf_list_item ** item_pp, uint32_t * id_p, axc_buf * data_p);
@@ -110,7 +110,8 @@ void axc_cleanup(axc_context * ctx_p);
 
 /**
  * "Installs" the library by creating the database and saving the necessary encryption keys into it.
- * Needs to be called once at the beginning, but can be called at every startup as it will not touch an initialized database.
+ * Needs to be called once at the beginning, but can be called at every startup as it will not touch an initialized
+ * database.
  *
  * @param ctx_p Pointer to the axc context as received from axc_init().
  * @return 0 on success, negative on failure
@@ -143,7 +144,8 @@ void axc_buf_free(axc_buf * buf);
  * @param ciphertext_pp Will point to the serialized ciphertext afterwards.
  * @return 0 on success, negative on error.
  */
-int axc_message_encrypt_and_serialize(axc_buf * msg_p, const axc_address * recipient_addr_p, axc_context * ctx_p, axc_buf ** ciphertext_pp);
+int axc_message_encrypt_and_serialize(axc_buf * msg_p, const axc_address * recipient_addr_p, axc_context * ctx_p,
+                                      axc_buf ** ciphertext_pp);
 
 /**
  * Decrypts a received message. Needs an established session.
@@ -157,7 +159,8 @@ int axc_message_encrypt_and_serialize(axc_buf * msg_p, const axc_address * recip
  * @param plaintext_pp Will point to the plaintext afterwards. Has to be freed.
  * @return 0 on success, negative on error.
  */
-int axc_message_decrypt_from_serialized (axc_buf * msg_p, axc_address * sender_addr_p, axc_context * ctx_p, axc_buf ** plaintext_pp);
+int axc_message_decrypt_from_serialized(axc_buf * msg_p, axc_address * sender_addr_p, axc_context * ctx_p,
+                                        axc_buf ** plaintext_pp);
 
 /**
  * Checks if an initiated session exists (and no pending synchronous handshake).
@@ -183,20 +186,18 @@ int axc_session_exists_any(const char * name, axc_context * ctx_p);
  * @param pre_key_id The ID of the used prekey.
  * @param pre_key_public_serialized_p Pointer to a buffer containing the serialized public part of the pre key pair.
  * @param signed_pre_key_id The ID of the signed prekey.
- * @param signed_pre_key_public_serialized_p Pointer to a buffer containing the serialized public part of the signed pre key pair.
+ * @param signed_pre_key_public_serialized_p Pointer to a buffer containing the serialized public part of the signed pre
+ * key pair.
  * @param signed_pre_key_signature_p Pointer to a buffer containing the signature data of the signed pre key.
- * @param identity_key_public_serialized_p Pointer to a buffer containing the serialized public part of the identity key pair.
+ * @param identity_key_public_serialized_p Pointer to a buffer containing the serialized public part of the identity key
+ * pair.
  * @param remote_address_p Pointer to the address of the recipient.
  * @param ctx_p Pointer to the axc_context.
  * @return 0 on success, negative on error.
  */
-int axc_session_from_bundle(uint32_t pre_key_id,
-                            axc_buf * pre_key_public_serialized_p,
-                            uint32_t signed_pre_key_id,
-                            axc_buf * signed_pre_key_public_serialized_p,
-                            axc_buf * signed_pre_key_signature_p,
-                            axc_buf * identity_key_public_serialized_p,
-                            const axc_address * remote_address_p,
+int axc_session_from_bundle(uint32_t pre_key_id, axc_buf * pre_key_public_serialized_p, uint32_t signed_pre_key_id,
+                            axc_buf * signed_pre_key_public_serialized_p, axc_buf * signed_pre_key_signature_p,
+                            axc_buf * identity_key_public_serialized_p, const axc_address * remote_address_p,
                             axc_context * ctx_p);
 
 /**
@@ -211,7 +212,8 @@ int axc_session_delete(const char * user, uint32_t device_id, axc_context * ctx_
 
 /**
  * Creates a session from a received pre key message and uses it to decrypt the actual message body.
- * The ciphertext is decrypted here to avoid reserializing the message or having to deal with internal axolotl data structures.
+ * The ciphertext is decrypted here to avoid reserializing the message or having to deal with internal axolotl data
+ * structures.
  *
  * @param pre_key_msg_serialized_p Pointer to the buffer containing the serialized message.
  * @param remote_address_p Pointer to the remote (sender) address.
@@ -219,7 +221,8 @@ int axc_session_delete(const char * user, uint32_t device_id, axc_context * ctx_
  * @param msg_pp Will contain a pointer to the decrypted plaintext.
  * @return 0 on success, negative on error
  */
-int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address * remote_address_p, axc_context * ctx_p, axc_buf ** plaintext_pp);
+int axc_pre_key_message_process(axc_buf * pre_key_msg_serialized_p, axc_address * remote_address_p, axc_context * ctx_p,
+                                axc_buf ** plaintext_pp);
 
 /**
  * Retrieves the own public identity key.

--- a/src/axc_crypto.c
+++ b/src/axc_crypto.c
@@ -4,10 +4,9 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
-#include <stdint.h> // int types
-#include <stdio.h> // fprintf
-#include <stdlib.h> // malloc
+#include <stdint.h>  // int types
+#include <stdio.h>   // fprintf
+#include <stdlib.h>  // malloc
 
 #include <gcrypt.h>
 
@@ -16,20 +15,19 @@
 #include "axc.h"
 
 void axc_crypto_init(void) {
-  (void) gcry_check_version((void *) 0);
+  (void)gcry_check_version((void *)0);
   gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
-  gcry_control (GCRYCTL_INIT_SECMEM, 16384, 0);
-  gcry_control (GCRYCTL_RESUME_SECMEM_WARN);
+  gcry_control(GCRYCTL_INIT_SECMEM, 16384, 0);
+  gcry_control(GCRYCTL_RESUME_SECMEM_WARN);
   gcry_control(GCRYCTL_USE_SECURE_RNDPOOL);
-  gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
+  gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
 }
 
-void axc_crypto_teardown(void) {
-}
+void axc_crypto_teardown(void) {}
 
 int random_bytes(uint8_t * data_p, size_t len, void * user_data_p) {
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
-  (void) axc_ctx_p;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
+  (void)axc_ctx_p;
 
   gcry_randomize(data_p, len, GCRY_STRONG_RANDOM);
 
@@ -37,11 +35,11 @@ int random_bytes(uint8_t * data_p, size_t len, void * user_data_p) {
 }
 
 int hmac_sha256_init(void ** hmac_context_pp, const uint8_t * key_p, size_t key_len, void * user_data_p) {
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
   int ret_val = 0;
-  char * err_msg = (void *) 0;
+  char * err_msg = (void *)0;
 
-  gcry_mac_hd_t * hmac_hd_p = (void *) 0;
+  gcry_mac_hd_t * hmac_hd_p = (void *)0;
 
   hmac_hd_p = malloc(sizeof(gcry_mac_hd_t));
   if (!hmac_hd_p) {
@@ -50,7 +48,7 @@ int hmac_sha256_init(void ** hmac_context_pp, const uint8_t * key_p, size_t key_
     goto cleanup;
   }
 
-  ret_val = gcry_mac_open(hmac_hd_p, GCRY_MAC_HMAC_SHA256, 0, (void *) 0);
+  ret_val = gcry_mac_open(hmac_hd_p, GCRY_MAC_HMAC_SHA256, 0, (void *)0);
   if (ret_val) {
     err_msg = "could not create hmac-sha256 ctx";
     goto cleanup;
@@ -67,7 +65,8 @@ int hmac_sha256_init(void ** hmac_context_pp, const uint8_t * key_p, size_t key_
 cleanup:
   if (ret_val) {
     if (ret_val > 0) {
-      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val), gcry_strerror(ret_val));
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val),
+              gcry_strerror(ret_val));
       ret_val = SG_ERR_UNKNOWN;
     } else {
       axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);
@@ -83,23 +82,23 @@ cleanup:
 }
 
 int hmac_sha256_update(void * hmac_context_p, const uint8_t * data_p, size_t data_len, void * user_data_p) {
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
-  (void) axc_ctx_p;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
+  (void)axc_ctx_p;
 
-  gcry_mac_write(*((gcry_mac_hd_t *) hmac_context_p), data_p, data_len);
+  gcry_mac_write(*((gcry_mac_hd_t *)hmac_context_p), data_p, data_len);
 
   return SG_SUCCESS;
 }
 
 int hmac_sha256_final(void * hmac_context_p, signal_buffer ** output_pp, void * user_data_p) {
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
   int ret_val = 0;
-  char * err_msg = (void *) 0;
+  char * err_msg = (void *)0;
 
   int algo = GCRY_MAC_HMAC_SHA256;
   size_t mac_len = 0;
-  uint8_t * mac_data_p = (void *) 0;
-  signal_buffer * out_buf_p = (void *) 0;
+  uint8_t * mac_data_p = (void *)0;
+  signal_buffer * out_buf_p = (void *)0;
 
   mac_len = gcry_mac_get_algo_maclen(algo);
 
@@ -110,7 +109,7 @@ int hmac_sha256_final(void * hmac_context_p, signal_buffer ** output_pp, void * 
     goto cleanup;
   }
 
-  ret_val = gcry_mac_read(*((gcry_mac_hd_t *) hmac_context_p), mac_data_p, &mac_len);
+  ret_val = gcry_mac_read(*((gcry_mac_hd_t *)hmac_context_p), mac_data_p, &mac_len);
   if (ret_val) {
     err_msg = "failed to read mac";
     goto cleanup;
@@ -126,34 +125,35 @@ int hmac_sha256_final(void * hmac_context_p, signal_buffer ** output_pp, void * 
   *output_pp = out_buf_p;
 
 cleanup:
-if (ret_val) {
-  if (ret_val > 0) {
-    axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val), gcry_strerror(ret_val));
-    ret_val = SG_ERR_UNKNOWN;
-  } else {
-    axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);
+  if (ret_val) {
+    if (ret_val > 0) {
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val),
+              gcry_strerror(ret_val));
+      ret_val = SG_ERR_UNKNOWN;
+    } else {
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);
+    }
   }
-}
   free(mac_data_p);
 
   return ret_val;
 }
 
 void hmac_sha256_cleanup(void * hmac_context_p, void * user_data_p) {
-  (void) user_data_p;
+  (void)user_data_p;
 
-  gcry_mac_hd_t * mac_hd_p = (gcry_mac_hd_t *) hmac_context_p;
+  gcry_mac_hd_t * mac_hd_p = (gcry_mac_hd_t *)hmac_context_p;
 
   gcry_mac_close(*mac_hd_p);
   free(mac_hd_p);
 }
 
 int sha512_digest_init(void ** digest_context_pp, void * user_data_p) {
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
   int ret_val = 0;
-  char * err_msg = (void *) 0;
+  char * err_msg = (void *)0;
 
-  gcry_md_hd_t * hash_hd_p = (void *) 0;
+  gcry_md_hd_t * hash_hd_p = (void *)0;
   hash_hd_p = malloc(sizeof(gcry_mac_hd_t));
   if (!hash_hd_p) {
     err_msg = "could not malloc sha512 ctx";
@@ -172,7 +172,8 @@ int sha512_digest_init(void ** digest_context_pp, void * user_data_p) {
 cleanup:
   if (ret_val) {
     if (ret_val > 0) {
-      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val), gcry_strerror(ret_val));
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val),
+              gcry_strerror(ret_val));
       ret_val = SG_ERR_UNKNOWN;
     } else {
       axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);
@@ -188,23 +189,23 @@ cleanup:
 }
 
 int sha512_digest_update(void * digest_context_p, const uint8_t * data_p, size_t data_len, void * user_data_p) {
-  (void) user_data_p;
+  (void)user_data_p;
 
-  gcry_md_write(*((gcry_md_hd_t *) digest_context_p), data_p, data_len);
+  gcry_md_write(*((gcry_md_hd_t *)digest_context_p), data_p, data_len);
 
   return 0;
 }
 
 int sha512_digest_final(void * digest_context_p, signal_buffer ** output_pp, void * user_data_p) {
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
-  gcry_md_hd_t * hash_hd_p = (gcry_md_hd_t *) digest_context_p;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
+  gcry_md_hd_t * hash_hd_p = (gcry_md_hd_t *)digest_context_p;
   int ret_val = 0;
-  char * err_msg = (void *) 0;
+  char * err_msg = (void *)0;
 
   int algo = GCRY_MD_SHA512;
   size_t hash_len = 0;
-  unsigned char * hash_data_p = (void *) 0;
-  signal_buffer * out_buf_p = (void *) 0;
+  unsigned char * hash_data_p = (void *)0;
+  signal_buffer * out_buf_p = (void *)0;
 
   hash_len = gcry_md_get_algo_dlen(algo);
 
@@ -215,7 +216,7 @@ int sha512_digest_final(void * digest_context_p, signal_buffer ** output_pp, voi
     goto cleanup;
   }
 
-  out_buf_p = signal_buffer_create((uint8_t *) hash_data_p, hash_len);
+  out_buf_p = signal_buffer_create((uint8_t *)hash_data_p, hash_len);
   if (!out_buf_p) {
     ret_val = SG_ERR_NOMEM;
     err_msg = "failed to create hash output buf";
@@ -227,22 +228,23 @@ int sha512_digest_final(void * digest_context_p, signal_buffer ** output_pp, voi
   *output_pp = out_buf_p;
 
 cleanup:
-if (ret_val) {
-  if (ret_val > 0) {
-    axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val), gcry_strerror(ret_val));
-    ret_val = SG_ERR_UNKNOWN;
-  } else {
-    axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);
+  if (ret_val) {
+    if (ret_val > 0) {
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val),
+              gcry_strerror(ret_val));
+      ret_val = SG_ERR_UNKNOWN;
+    } else {
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);
+    }
   }
-}
 
   return ret_val;
 }
 
 void sha512_digest_cleanup(void * digest_context_p, void * user_data_p) {
-  (void) user_data_p;
+  (void)user_data_p;
 
-  gcry_md_hd_t * hash_hd_p = (gcry_md_hd_t *) digest_context_p;
+  gcry_md_hd_t * hash_hd_p = (gcry_md_hd_t *)digest_context_p;
 
   gcry_md_close(*hash_hd_p);
   free(hash_hd_p);
@@ -252,7 +254,7 @@ static int choose_aes(int cipher, size_t key_len, int * algo_p, int * mode_p) {
   int algo = 0;
   int mode = 0;
 
-  switch(key_len) {
+  switch (key_len) {
     case 16:
       algo = GCRY_CIPHER_AES128;
       break;
@@ -283,27 +285,22 @@ static int choose_aes(int cipher, size_t key_len, int * algo_p, int * mode_p) {
   return 0;
 }
 
-int aes_encrypt(signal_buffer ** output_pp,
-        int cipher,
-        const uint8_t * key_p, size_t key_len,
-        const uint8_t * iv_p, size_t iv_len,
-        const uint8_t * plaintext_p, size_t plaintext_len,
-        void * user_data_p) {
-
+int aes_encrypt(signal_buffer ** output_pp, int cipher, const uint8_t * key_p, size_t key_len, const uint8_t * iv_p,
+                size_t iv_len, const uint8_t * plaintext_p, size_t plaintext_len, void * user_data_p) {
   int ret_val = SG_SUCCESS;
-  char * err_msg = (void *) 0;
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
+  char * err_msg = (void *)0;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
 
   int algo = 0;
   int mode = 0;
   size_t pad_len = 0;
   size_t ct_len = 0;
   gcry_cipher_hd_t cipher_hd = {0};
-  uint8_t * pt_p = (void *) 0;
-  uint8_t * out_p = (void *) 0;
-  signal_buffer * out_buf_p = (void *) 0;
+  uint8_t * pt_p = (void *)0;
+  uint8_t * out_p = (void *)0;
+  signal_buffer * out_buf_p = (void *)0;
 
-  if(iv_len != 16) {
+  if (iv_len != 16) {
     err_msg = "invalid AES IV size (must be 16)";
     ret_val = SG_ERR_UNKNOWN;
     goto cleanup;
@@ -383,7 +380,8 @@ int aes_encrypt(signal_buffer ** output_pp,
 cleanup:
   if (ret_val) {
     if (ret_val > 0) {
-      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val), gcry_strerror(ret_val));
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val),
+              gcry_strerror(ret_val));
       ret_val = SG_ERR_UNKNOWN;
     } else {
       axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);
@@ -397,25 +395,20 @@ cleanup:
   return ret_val;
 }
 
-int aes_decrypt(signal_buffer ** output_pp,
-        int cipher,
-        const uint8_t * key_p, size_t key_len,
-        const uint8_t * iv_p, size_t iv_len,
-        const uint8_t * ciphertext_p, size_t ciphertext_len,
-        void * user_data_p) {
-
+int aes_decrypt(signal_buffer ** output_pp, int cipher, const uint8_t * key_p, size_t key_len, const uint8_t * iv_p,
+                size_t iv_len, const uint8_t * ciphertext_p, size_t ciphertext_len, void * user_data_p) {
   int ret_val = SG_SUCCESS;
-  char * err_msg = (void *) 0;
-  axc_context * axc_ctx_p = (axc_context *) user_data_p;
+  char * err_msg = (void *)0;
+  axc_context * axc_ctx_p = (axc_context *)user_data_p;
 
   int algo = 0;
   int mode = 0;
   gcry_cipher_hd_t cipher_hd = {0};
-  uint8_t * out_p = (void *) 0;
+  uint8_t * out_p = (void *)0;
   size_t pad_len = 0;
-  signal_buffer * out_buf_p = (void *) 0;
+  signal_buffer * out_buf_p = (void *)0;
 
-  if(iv_len != 16) {
+  if (iv_len != 16) {
     err_msg = "invalid AES IV size (must be 16)";
     ret_val = SG_ERR_UNKNOWN;
     goto cleanup;
@@ -482,11 +475,11 @@ int aes_decrypt(signal_buffer ** output_pp,
   out_buf_p = signal_buffer_create(out_p, ciphertext_len - pad_len);
   *output_pp = out_buf_p;
 
-
 cleanup:
   if (ret_val) {
     if (ret_val > 0) {
-      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val), gcry_strerror(ret_val));
+      axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s (%s: %s)\n", __func__, err_msg, gcry_strsource(ret_val),
+              gcry_strerror(ret_val));
       ret_val = SG_ERR_UNKNOWN;
     } else {
       axc_log(axc_ctx_p, AXC_LOG_ERROR, "%s: %s\n", __func__, err_msg);

--- a/src/axc_crypto.h
+++ b/src/axc_crypto.h
@@ -4,7 +4,6 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
 #pragma once
 
 #include <stdint.h>
@@ -26,15 +25,7 @@ int sha512_digest_update(void * digest_context_p, const uint8_t * data_p, size_t
 int sha512_digest_final(void * digest_context_p, signal_buffer ** output_pp, void * user_data_p);
 void sha512_digest_cleanup(void * digest_context_p, void * user_data_p);
 
-int aes_encrypt(signal_buffer ** output_pp,
-        int cipher,
-        const uint8_t * key_p, size_t key_len,
-        const uint8_t * iv_p, size_t iv_len,
-        const uint8_t * plaintext_p, size_t plaintext_len,
-        void * user_data_p);
-int aes_decrypt(signal_buffer ** output_pp,
-        int cipher,
-        const uint8_t * key_p, size_t key_len,
-        const uint8_t * iv_p, size_t iv_len,
-        const uint8_t * ciphertext_p, size_t ciphertext_len,
-        void * user_data_p);
+int aes_encrypt(signal_buffer ** output_pp, int cipher, const uint8_t * key_p, size_t key_len, const uint8_t * iv_p,
+                size_t iv_len, const uint8_t * plaintext_p, size_t plaintext_len, void * user_data_p);
+int aes_decrypt(signal_buffer ** output_pp, int cipher, const uint8_t * key_p, size_t key_len, const uint8_t * iv_p,
+                size_t iv_len, const uint8_t * ciphertext_p, size_t ciphertext_len, void * user_data_p);

--- a/src/axc_store.h
+++ b/src/axc_store.h
@@ -4,7 +4,6 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
 #pragma once
 
 #include "signal_protocol.h"
@@ -16,29 +15,33 @@
 // Function signatures implementing their interfaces intentionally left in their code style.
 
 #define AXC_DB_NOT_INITIALIZED (-1)
-#define AXC_DB_NEEDS_ROLLBACK    0
-#define AXC_DB_INITIALIZED       1
+#define AXC_DB_NEEDS_ROLLBACK  0
+#define AXC_DB_INITIALIZED     1
 
 // session store
-int axc_db_session_load(signal_buffer **record, signal_buffer **user_record, const signal_protocol_address *address, void *user_data);
-int axc_db_session_get_sub_device_sessions(signal_int_list **sessions, const char *name, size_t name_len, void *user_data);
-int axc_db_session_store(const signal_protocol_address *address, uint8_t *record, size_t record_len, uint8_t *user_record, size_t user_record_len, void *user_data);
-int axc_db_session_contains(const signal_protocol_address *address, void *user_data);
-int axc_db_session_delete(const signal_protocol_address *address, void *user_data);
-int axc_db_session_delete_all(const char *name, size_t name_len, void *user_data);
-void axc_db_session_destroy_store_ctx(void *user_data);
+int axc_db_session_load(signal_buffer ** record, signal_buffer ** user_record, const signal_protocol_address * address,
+                        void * user_data);
+int axc_db_session_get_sub_device_sessions(signal_int_list ** sessions, const char * name, size_t name_len,
+                                           void * user_data);
+int axc_db_session_store(const signal_protocol_address * address, uint8_t * record, size_t record_len,
+                         uint8_t * user_record, size_t user_record_len, void * user_data);
+int axc_db_session_contains(const signal_protocol_address * address, void * user_data);
+int axc_db_session_delete(const signal_protocol_address * address, void * user_data);
+int axc_db_session_delete_all(const char * name, size_t name_len, void * user_data);
+void axc_db_session_destroy_store_ctx(void * user_data);
 
 // pre key store
-int axc_db_pre_key_load(signal_buffer **record, uint32_t pre_key_id, void *user_data);
-int axc_db_pre_key_store(uint32_t pre_key_id, uint8_t *record, size_t record_len, void *user_data);
-int axc_db_pre_key_contains(uint32_t pre_key_id, void *user_data);
-int axc_db_pre_key_remove(uint32_t pre_key_id, void *user_data);
-void axc_db_pre_key_destroy_ctx(void *user_data);
+int axc_db_pre_key_load(signal_buffer ** record, uint32_t pre_key_id, void * user_data);
+int axc_db_pre_key_store(uint32_t pre_key_id, uint8_t * record, size_t record_len, void * user_data);
+int axc_db_pre_key_contains(uint32_t pre_key_id, void * user_data);
+int axc_db_pre_key_remove(uint32_t pre_key_id, void * user_data);
+void axc_db_pre_key_destroy_ctx(void * user_data);
 /**
  * Stores a whole list of pre keys at once, inside a single transaction.
  *
  * @param pre_keys_head Pointer to the first element of the list.
- * @param user_data_p Optional. The user_data as received from the axolotl interface, will be used to set the database name.
+ * @param user_data_p Optional. The user_data as received from the axolotl interface, will be used to set the database
+ * name.
  */
 int axc_db_pre_key_store_list(signal_protocol_key_helper_pre_key_list_node * pre_keys_head, axc_context * ctx_p);
 
@@ -72,23 +75,26 @@ int axc_db_pre_key_get_max_id(axc_context * ctx_p, uint32_t * max_id_p);
 int axc_db_pre_key_get_count(axc_context * ctx_p, size_t * count_p);
 
 // signed pre key store
-int axc_db_signed_pre_key_load(signal_buffer **record, uint32_t signed_pre_key_id, void *user_data);
-int axc_db_signed_pre_key_store(uint32_t signed_pre_key_id, uint8_t *record, size_t record_len, void *user_data);
-int axc_db_signed_pre_key_contains(uint32_t signed_pre_key_id, void *user_data);
-int axc_db_signed_pre_key_remove(uint32_t signed_pre_key_id, void *user_data);
-void axc_db_signed_pre_key_destroy_ctx(void *user_data);
+int axc_db_signed_pre_key_load(signal_buffer ** record, uint32_t signed_pre_key_id, void * user_data);
+int axc_db_signed_pre_key_store(uint32_t signed_pre_key_id, uint8_t * record, size_t record_len, void * user_data);
+int axc_db_signed_pre_key_contains(uint32_t signed_pre_key_id, void * user_data);
+int axc_db_signed_pre_key_remove(uint32_t signed_pre_key_id, void * user_data);
+void axc_db_signed_pre_key_destroy_ctx(void * user_data);
 
 // identity key store
-int axc_db_identity_get_key_pair(signal_buffer **public_data, signal_buffer **private_data, void *user_data);
-int axc_db_identity_get_local_registration_id(void *user_data, uint32_t *registration_id);
-int axc_db_identity_save(const signal_protocol_address * addr_p, uint8_t *key_data, size_t key_len, void *user_data);
-int axc_db_identity_is_trusted(const char *name, size_t name_len, uint8_t *key_data, size_t key_len, void *user_data);
-int axc_db_identity_always_trusted(const signal_protocol_address * addr_p, uint8_t * key_data, size_t key_len, void * user_data);
-void axc_db_identity_destroy_ctx(void *user_data);
+int axc_db_identity_get_key_pair(signal_buffer ** public_data, signal_buffer ** private_data, void * user_data);
+int axc_db_identity_get_local_registration_id(void * user_data, uint32_t * registration_id);
+int axc_db_identity_save(const signal_protocol_address * addr_p, uint8_t * key_data, size_t key_len, void * user_data);
+int axc_db_identity_is_trusted(const char * name, size_t name_len, uint8_t * key_data, size_t key_len,
+                               void * user_data);
+int axc_db_identity_always_trusted(const signal_protocol_address * addr_p, uint8_t * key_data, size_t key_len,
+                                   void * user_data);
+void axc_db_identity_destroy_ctx(void * user_data);
 
 // additional helper functions
 /**
- * Saves the public and private key by using the api serialization calls, as this format (and not the higher-level key type) is needed by the getter.
+ * Saves the public and private key by using the api serialization calls, as this format (and not the higher-level key
+ * type) is needed by the getter.
  *
  * @param Pointer to the keypair as returned by axolotl_key_helper_generate_identity_key_pair
  * @param axc_ctx_p Pointer to the axc context.
@@ -121,7 +127,6 @@ int axc_db_create(axc_context * axc_ctx_p);
  * @return 0 on success, negative on error
  */
 int axc_db_destroy(axc_context * axc_ctx_p);
-
 
 /**
  * Sets the value of a property in the database's "settings" table.

--- a/src/message_client.c
+++ b/src/message_client.c
@@ -4,100 +4,82 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
-#include <ctype.h> // toupper
-#include <stdio.h> // printf, getline
-#include <stdlib.h> // exit codes
-#include <string.h> // memset, strlen
+#include <ctype.h>   // toupper
+#include <stdio.h>   // printf, getline
+#include <stdlib.h>  // exit codes
+#include <string.h>  // memset, strlen
 
 #include "axc.h"
 
-#define FAIL0(lbl,...) do { ret = EXIT_FAILURE; fprintf(stderr, __VA_ARGS__); goto lbl; } while (0)
-#define FAIL(...) FAIL0(cleanup,__VA_ARGS__)
+#define FAIL0(lbl, ...)           \
+  do {                            \
+    ret = EXIT_FAILURE;           \
+    fprintf(stderr, __VA_ARGS__); \
+    goto lbl;                     \
+  } while (0)
+#define FAIL(...) FAIL0(cleanup, __VA_ARGS__)
 
 int main(void) {
   printf("sup\n");
   printf("initializing context for alice...\n");
   axc_context * ctx_a_p;
   int ret = EXIT_SUCCESS;
-  if (axc_context_create(&ctx_a_p))
-    FAIL0(cleanup_none, "failed to create axc context\n");
+  if (axc_context_create(&ctx_a_p)) FAIL0(cleanup_none, "failed to create axc context\n");
 
   axc_context_set_log_func(ctx_a_p, axc_default_log);
   axc_context_set_log_level(ctx_a_p, AXC_LOG_DEBUG);
 
   char * db_a_fn = "client/a.sqlite";
-  if (axc_context_set_db_fn(ctx_a_p, db_a_fn, strlen(db_a_fn)))
-    FAIL0(cleanup_a, "failed to set db filename\n");
+  if (axc_context_set_db_fn(ctx_a_p, db_a_fn, strlen(db_a_fn))) FAIL0(cleanup_a, "failed to set db filename\n");
 
   printf("set db fn\n");
 
-  if (axc_init(ctx_a_p))
-    FAIL0(cleanup_a, "failed to init axc\n");
+  if (axc_init(ctx_a_p)) FAIL0(cleanup_a, "failed to init axc\n");
 
   printf("installing client for alice...\n");
-  if (axc_install(ctx_a_p))
-    FAIL0(cleanup_a, "failed to install axc\n");
+  if (axc_install(ctx_a_p)) FAIL0(cleanup_a, "failed to install axc\n");
 
   printf("initializing context for bob...\n");
   axc_context * ctx_b_p;
-  if (axc_context_create(&ctx_b_p))
-    FAIL0(cleanup_a, "failed to create axc context\n");
+  if (axc_context_create(&ctx_b_p)) FAIL0(cleanup_a, "failed to create axc context\n");
 
   char * db_b_fn = "client/b.sqlite";
-  if (axc_context_set_db_fn(ctx_b_p, db_b_fn, strlen(db_b_fn)))
-    FAIL("failed to set db filename\n");
+  if (axc_context_set_db_fn(ctx_b_p, db_b_fn, strlen(db_b_fn))) FAIL("failed to set db filename\n");
 
   axc_context_set_log_func(ctx_b_p, axc_default_log);
   axc_context_set_log_level(ctx_b_p, AXC_LOG_DEBUG);
 
-  if (axc_init(ctx_b_p))
-    FAIL("failed to init axc\n");
+  if (axc_init(ctx_b_p)) FAIL("failed to init axc\n");
 
   printf("installing client for bob...\n");
-  if (axc_install(ctx_b_p))
-    FAIL("failed to install axc\n");
+  if (axc_install(ctx_b_p)) FAIL("failed to install axc\n");
 
-  axc_address addr_a = {
-      .name = "alice",
-      .name_len = 5,
-      .device_id = 1
-  };
+  axc_address addr_a = {.name = "alice", .name_len = 5, .device_id = 1};
 
-  axc_address addr_b = {
-      .name = "bob",
-      .name_len = 3,
-      .device_id = 1
-  };
+  axc_address addr_b = {.name = "bob", .name_len = 3, .device_id = 1};
 
   printf("checking if session already exists\n");
   if (!axc_session_exists_initiated(&addr_b, ctx_a_p)) {
     printf("creating session between alice and bob\n");
-    axc_bundle *bundle_bob;
-    if (axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob))
-      FAIL("failed to collect bob's bundle\n");
+    axc_bundle * bundle_bob;
+    if (axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob)) FAIL("failed to collect bob's bundle\n");
     // addr_b.device_id = axc_bundle_get_reg_id(bundle_bob);
     if (axc_session_from_bundle(axc_buf_list_item_get_id(axc_bundle_get_pre_key_list(bundle_bob)),
                                 axc_buf_list_item_get_buf(axc_bundle_get_pre_key_list(bundle_bob)),
-                                axc_bundle_get_signed_pre_key_id(bundle_bob),
-                                axc_bundle_get_signed_pre_key(bundle_bob),
-                                axc_bundle_get_signature(bundle_bob),
-                                axc_bundle_get_identity_key(bundle_bob),
-                                &addr_b,
+                                axc_bundle_get_signed_pre_key_id(bundle_bob), axc_bundle_get_signed_pre_key(bundle_bob),
+                                axc_bundle_get_signature(bundle_bob), axc_bundle_get_identity_key(bundle_bob), &addr_b,
                                 ctx_a_p))
       FAIL("failed to create session from bob's bundle\n");
     axc_bundle_destroy(bundle_bob);
     axc_buf * msg_buf_p = axc_buf_create((const uint8_t *)"hello", strlen("hello") + 1);
-    if (!msg_buf_p)
-      FAIL("failed to create 'hello' msg buffer\n");
+    if (!msg_buf_p) FAIL("failed to create 'hello' msg buffer\n");
 
     axc_buf * ct_buf_p;
     if (axc_message_encrypt_and_serialize(msg_buf_p, &addr_b, ctx_a_p, &ct_buf_p))
       FAIL("failed to encrypt 'hello' message\n");
 
     uint32_t alice_id;
-    if (axc_get_device_id(ctx_a_p, &alice_id))
-      FAIL("failed to retrieve alice's device_id\n");
+    if (axc_get_device_id(ctx_a_p, &alice_id)) FAIL("failed to retrieve alice's device_id\n");
     addr_a.device_id = alice_id;
 
     axc_buf * pt_buf_p;
@@ -120,23 +102,22 @@ int main(void) {
   } else {
     printf("session exists.\n");
     uint32_t alice_id;
-    if (axc_get_device_id(ctx_a_p, &alice_id))
-      FAIL("failed to retrieve alice's device_id\n");
+    if (axc_get_device_id(ctx_a_p, &alice_id)) FAIL("failed to retrieve alice's device_id\n");
     addr_a.device_id = alice_id;
   }
   printf("now trying to ready to 'send' and 'receive' messages\n");
 
-  char * line = (void *) 0;
+  char * line = (void *)0;
   size_t len = 0;
   printf("enter message: ");
-  while(getline(&line, &len, stdin) > 0) {
+  while (getline(&line, &len, stdin) > 0) {
     axc_buf * ciphertext_p;
     {
-    axc_buf * msg_p = axc_buf_create((uint8_t *) line, strlen(line) + 1);
-    if (axc_message_encrypt_and_serialize(msg_p, &addr_b, ctx_a_p, &ciphertext_p))
-      FAIL("failed to encrypt message from alice to bob\n");
-    printf("encrypted message from alice to bob: %s\n", line);
-    axc_buf_free(msg_p);
+      axc_buf * msg_p = axc_buf_create((uint8_t *)line, strlen(line) + 1);
+      if (axc_message_encrypt_and_serialize(msg_p, &addr_b, ctx_a_p, &ciphertext_p))
+        FAIL("failed to encrypt message from alice to bob\n");
+      printf("encrypted message from alice to bob: %s\n", line);
+      axc_buf_free(msg_p);
     }
 
     uint8_t * buf = signal_buffer_data(ciphertext_p);
@@ -161,7 +142,7 @@ int main(void) {
     }
     printf("bob sending reply...\n");
 
-    upper_buf = axc_buf_create((uint8_t *) upper, strlen(upper) + 1);
+    upper_buf = axc_buf_create((uint8_t *)upper, strlen(upper) + 1);
     axc_buf_free(plaintext_p);
 
     if (axc_message_encrypt_and_serialize(upper_buf, &addr_a, ctx_b_p, &ciphertext_p))

--- a/test/test_client.c
+++ b/test/test_client.c
@@ -4,7 +4,6 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -27,11 +26,11 @@ signal_protocol_address addr_bob_12 = {.name = "bob", .name_len = 3, .device_id 
 axc_address addr_bob = {.name = "bob", .name_len = 3, .device_id = 0};
 
 axc_context * ctx_global_p;
-axc_context * ctx_a_p = (void *) 0;
-axc_context * ctx_b_p = (void *) 0;
+axc_context * ctx_a_p = (void *)0;
+axc_context * ctx_b_p = (void *)0;
 
 int global_setup(void ** state) {
-  (void) state;
+  (void)state;
 
   axc_crypto_init();
 
@@ -39,41 +38,41 @@ int global_setup(void ** state) {
 }
 
 int global_teardown(void ** state) {
-  (void) state;
+  (void)state;
 
   axc_crypto_teardown();
 
   return 0;
 }
 
-int client_setup(void **state) {
-  (void) state;
+int client_setup(void ** state) {
+  (void)state;
 
-  ctx_global_p = (void *) 0;
+  ctx_global_p = (void *)0;
 
   assert_int_equal(axc_context_create(&ctx_global_p), 0);
   assert_int_equal(axc_context_set_db_fn(ctx_global_p, test_fn, strlen(test_fn)), 0);
-  //axc_context_set_log_func(ctx_global_p, axc_default_log);
-  //axc_context_set_log_level(ctx_global_p, AXC_LOG_DEBUG);
+  // axc_context_set_log_func(ctx_global_p, axc_default_log);
+  // axc_context_set_log_level(ctx_global_p, AXC_LOG_DEBUG);
 
   return axc_init(ctx_global_p);
 }
 
 int client_teardown(void ** state) {
-  (void) state;
+  (void)state;
 
   axc_crypto_teardown();
   axc_cleanup(ctx_global_p);
-  ctx_global_p = (void *) 0;
+  ctx_global_p = (void *)0;
   remove(test_fn);
   return 0;
 }
 
 int client_setup_two_dbs(void ** state) {
-  (void) state;
+  (void)state;
 
-  ctx_a_p = (void *) 0;
-  ctx_b_p = (void *) 0;
+  ctx_a_p = (void *)0;
+  ctx_b_p = (void *)0;
 
   assert_int_equal(axc_context_create(&ctx_a_p), 0);
   assert_int_equal(axc_context_create(&ctx_b_p), 0);
@@ -104,19 +103,16 @@ int client_setup_sessions(void ** state) {
   assert_int_equal(axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob_p), 0);
   addr_bob.device_id = bundle_bob_p->registration_id;
 
-  assert_int_equal(axc_session_from_bundle(axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
-                                            axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p),
-                                            bundle_bob_p->signed_pre_key_id,
-                                            bundle_bob_p->signed_pre_key_public_serialized_p,
-                                            bundle_bob_p->signed_pre_key_signature_p,
-                                            bundle_bob_p->identity_key_public_serialized_p,
-                                            &addr_bob,
-                                            ctx_a_p),
-                    0);
+  assert_int_equal(axc_session_from_bundle(
+                       axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
+                       axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p), bundle_bob_p->signed_pre_key_id,
+                       bundle_bob_p->signed_pre_key_public_serialized_p, bundle_bob_p->signed_pre_key_signature_p,
+                       bundle_bob_p->identity_key_public_serialized_p, &addr_bob, ctx_a_p),
+                   0);
 
   const char * data = "hello";
-  axc_buf * msg_buf_p = axc_buf_create((uint8_t *) data, strlen(data) + 1);
-  assert_ptr_not_equal(msg_buf_p, (void *) 0);
+  axc_buf * msg_buf_p = axc_buf_create((uint8_t *)data, strlen(data) + 1);
+  assert_ptr_not_equal(msg_buf_p, (void *)0);
 
   axc_buf * ct_buf_p;
   assert_int_equal(axc_message_encrypt_and_serialize(msg_buf_p, &addr_bob, ctx_a_p, &ct_buf_p), 0);
@@ -145,8 +141,8 @@ int client_setup_sessions(void ** state) {
   return 0;
 }
 
-int client_teardown_two_dbs(void **state) {
-  (void) state;
+int client_teardown_two_dbs(void ** state) {
+  (void)state;
 
   axc_cleanup(ctx_a_p);
   axc_cleanup(ctx_b_p);
@@ -157,91 +153,93 @@ int client_teardown_two_dbs(void **state) {
   return 0;
 }
 
-void test_init(void **state) {
-  (void) state;
+void test_init(void ** state) {
+  (void)state;
 
-  ctx_global_p = (void *) 0;
+  ctx_global_p = (void *)0;
   assert_int_equal(axc_context_create(&ctx_global_p), 0);
-  assert_ptr_not_equal(ctx_global_p, (void *) 0);
+  assert_ptr_not_equal(ctx_global_p, (void *)0);
 
   assert_int_equal(axc_context_set_db_fn(ctx_global_p, test_fn, strlen(test_fn)), 0);
   assert_int_equal(axc_init(ctx_global_p), 0);
 
-  #ifndef NO_THREADS
-  assert_ptr_not_equal(ctx_global_p->mutexes_p, (void *) 0);
-  assert_ptr_not_equal(ctx_global_p->mutexes_p->mutex_p, (void *) 0);
-  assert_ptr_not_equal(ctx_global_p->mutexes_p->mutex_attr_p, (void *) 0);
+#ifndef NO_THREADS
+  assert_ptr_not_equal(ctx_global_p->mutexes_p, (void *)0);
+  assert_ptr_not_equal(ctx_global_p->mutexes_p->mutex_p, (void *)0);
+  assert_ptr_not_equal(ctx_global_p->mutexes_p->mutex_attr_p, (void *)0);
   int type = 0;
   assert_int_equal(pthread_mutexattr_gettype(ctx_global_p->mutexes_p->mutex_attr_p, &type), 0);
   assert_int_equal(type, PTHREAD_MUTEX_RECURSIVE);
-  #endif
+#endif
 
-  assert_ptr_not_equal(ctx_global_p->axolotl_global_context_p, (void *) 0);
+  assert_ptr_not_equal(ctx_global_p->axolotl_global_context_p, (void *)0);
 
-  assert_ptr_not_equal(ctx_global_p->axolotl_store_context_p, (void *) 0);
+  assert_ptr_not_equal(ctx_global_p->axolotl_store_context_p, (void *)0);
 }
 
-void test_recursive_mutex_lock(void **state) {
-  (void) state;
+void test_recursive_mutex_lock(void ** state) {
+  (void)state;
 
-  #ifndef NO_THREADS
-  assert_ptr_not_equal(ctx_global_p->mutexes_p, (void *) 0);
+#ifndef NO_THREADS
+  assert_ptr_not_equal(ctx_global_p->mutexes_p, (void *)0);
   recursive_mutex_lock(ctx_global_p);
   assert_int_equal(pthread_mutex_unlock(ctx_global_p->mutexes_p->mutex_p), 0);
-  #else
+#else
   skip();
-  #endif
+#endif
 }
 
-void test_recursive_mutex_unlock(void **state){
-  (void) state;
+void test_recursive_mutex_unlock(void ** state) {
+  (void)state;
 
-  #ifndef NO_THREADS
+#ifndef NO_THREADS
   recursive_mutex_lock(ctx_global_p);
   recursive_mutex_unlock(ctx_global_p);
   assert_int_not_equal(pthread_mutex_unlock(ctx_global_p->mutexes_p->mutex_p), 0);
-  #else
+#else
   skip();
-  #endif
+#endif
 }
 
-void test_install_should_generate_necessary_data(void **state) {
-  (void) state;
+void test_install_should_generate_necessary_data(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_install(ctx_global_p), 0);
 
-  sqlite3 * db_p = (void *) 0;
-  sqlite3_stmt * pstmt_p = (void *) 0;
+  sqlite3 * db_p = (void *)0;
+  sqlite3_stmt * pstmt_p = (void *)0;
 
   char stmt[100];
-  assert_int_not_equal(sprintf(stmt, "SELECT count(*) FROM identity_key_store WHERE name IS '%s';", OWN_PUBLIC_KEY_NAME), 0);
+  assert_int_not_equal(
+      sprintf(stmt, "SELECT count(*) FROM identity_key_store WHERE name IS '%s';", OWN_PUBLIC_KEY_NAME), 0);
   assert_int_equal(sqlite3_open(test_fn, &db_p), SQLITE_OK);
 
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_int_equal(sqlite3_column_int(pstmt_p, 0), 1);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
-  assert_int_not_equal(sprintf(stmt, "SELECT count(*) FROM identity_key_store WHERE name IS '%s';", OWN_PRIVATE_KEY_NAME), 0);
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_not_equal(
+      sprintf(stmt, "SELECT count(*) FROM identity_key_store WHERE name IS '%s';", OWN_PRIVATE_KEY_NAME), 0);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_int_equal(sqlite3_column_int(pstmt_p, 0), 1);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   assert_int_not_equal(sprintf(stmt, "SELECT count(*) FROM settings WHERE name IS '%s';", REG_ID_NAME), 0);
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_int_equal(sqlite3_column_int(pstmt_p, 0), 1);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   assert_int_not_equal(sprintf(stmt, "SELECT count(*) FROM pre_key_store;"), 0);
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_int_equal(sqlite3_column_int(pstmt_p, 0), AXC_PRE_KEYS_AMOUNT);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   assert_int_not_equal(sprintf(stmt, "SELECT count(*) FROM signed_pre_key_store;"), 0);
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_int_equal(sqlite3_column_int(pstmt_p, 0), 1);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
@@ -253,11 +251,11 @@ void test_install_should_generate_necessary_data(void **state) {
   assert_int_equal(result, AXC_DB_INITIALIZED);
 }
 
-void test_install_should_not_do_anything_if_already_initialiased(void **state) {
-  (void) state;
+void test_install_should_not_do_anything_if_already_initialiased(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_install(ctx_global_p), 0);
-  
+
   uint32_t reg_id_1 = 0;
   assert_int_equal(axc_db_identity_get_local_registration_id(ctx_global_p, &reg_id_1), 0);
   assert_int_not_equal(reg_id_1, 0);
@@ -270,11 +268,11 @@ void test_install_should_not_do_anything_if_already_initialiased(void **state) {
   assert_int_equal(reg_id_1, reg_id_2);
 }
 
-void test_install_should_reset_if_needed(void **state) {
-  (void) state;
+void test_install_should_reset_if_needed(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_install(ctx_global_p), 0);
-  
+
   uint32_t reg_id_1 = 0;
   assert_int_equal(axc_db_identity_get_local_registration_id(ctx_global_p, &reg_id_1), 0);
   assert_int_not_equal(reg_id_1, 0);
@@ -289,42 +287,42 @@ void test_install_should_reset_if_needed(void **state) {
   assert_int_not_equal(reg_id_1, reg_id_2);
 }
 
-void test_message_encrypt_decrypt(void **state) {
-  (void) state;
+void test_message_encrypt_decrypt(void ** state) {
+  (void)state;
 
-  axc_buf * msg_a1_p = axc_buf_create((uint8_t *) "hallo", 6);
-  axc_buf * msg_a2_p = axc_buf_create((uint8_t *) "sup", 4);
-  axc_buf * msg_b1_p = axc_buf_create((uint8_t *) "0123456789abcdef", 16);
-  axc_buf * msg_b2_p = axc_buf_create((uint8_t *) "na", 3);
+  axc_buf * msg_a1_p = axc_buf_create((uint8_t *)"hallo", 6);
+  axc_buf * msg_a2_p = axc_buf_create((uint8_t *)"sup", 4);
+  axc_buf * msg_b1_p = axc_buf_create((uint8_t *)"0123456789abcdef", 16);
+  axc_buf * msg_b2_p = axc_buf_create((uint8_t *)"na", 3);
 
-  assert_int_not_equal(axc_message_encrypt_and_serialize((void *) 0, (void *) 0, (void *) 0, (void *) 0), 0);
-  assert_int_not_equal(axc_message_encrypt_and_serialize(msg_a1_p, (void *) 0, (void *) 0, (void *) 0), 0);
-  assert_int_not_equal(axc_message_encrypt_and_serialize(msg_a1_p, &addr_bob_12, (void *) 0, (void *) 0), 0);
-  assert_int_not_equal(axc_message_encrypt_and_serialize(msg_a1_p, &addr_bob_12, ctx_a_p, (void *) 0), 0);
+  assert_int_not_equal(axc_message_encrypt_and_serialize((void *)0, (void *)0, (void *)0, (void *)0), 0);
+  assert_int_not_equal(axc_message_encrypt_and_serialize(msg_a1_p, (void *)0, (void *)0, (void *)0), 0);
+  assert_int_not_equal(axc_message_encrypt_and_serialize(msg_a1_p, &addr_bob_12, (void *)0, (void *)0), 0);
+  assert_int_not_equal(axc_message_encrypt_and_serialize(msg_a1_p, &addr_bob_12, ctx_a_p, (void *)0), 0);
 
-  axc_buf * ct_a1_p = (void *) 0;
-  axc_buf * ct_a2_p = (void *) 0;
+  axc_buf * ct_a1_p = (void *)0;
+  axc_buf * ct_a2_p = (void *)0;
   assert_int_equal(axc_message_encrypt_and_serialize(msg_a1_p, &addr_bob, ctx_a_p, &ct_a1_p), 0);
   assert_int_equal(axc_message_encrypt_and_serialize(msg_a2_p, &addr_bob, ctx_a_p, &ct_a2_p), 0);
 
-  axc_buf * pt_a1_p = (void *) 0;
-  axc_buf * pt_a2_p = (void *) 0;
+  axc_buf * pt_a1_p = (void *)0;
+  axc_buf * pt_a2_p = (void *)0;
 
-  assert_int_not_equal(axc_message_decrypt_from_serialized((void *) 0, (void *) 0, (void *) 0, (void *) 0), 0);
-  assert_int_not_equal(axc_message_decrypt_from_serialized(ct_a1_p, (void *) 0, (void *) 0, (void *) 0), 0);
-  assert_int_not_equal(axc_message_decrypt_from_serialized(ct_a1_p, &addr_alice, (void *) 0, (void *) 0), 0);
-  assert_int_not_equal(axc_message_decrypt_from_serialized(ct_a1_p, &addr_alice, ctx_b_p, (void *) 0), 0);
+  assert_int_not_equal(axc_message_decrypt_from_serialized((void *)0, (void *)0, (void *)0, (void *)0), 0);
+  assert_int_not_equal(axc_message_decrypt_from_serialized(ct_a1_p, (void *)0, (void *)0, (void *)0), 0);
+  assert_int_not_equal(axc_message_decrypt_from_serialized(ct_a1_p, &addr_alice, (void *)0, (void *)0), 0);
+  assert_int_not_equal(axc_message_decrypt_from_serialized(ct_a1_p, &addr_alice, ctx_b_p, (void *)0), 0);
 
   assert_int_equal(axc_message_decrypt_from_serialized(ct_a1_p, &addr_alice, ctx_b_p, &pt_a1_p), 0);
   assert_int_equal(axc_message_decrypt_from_serialized(ct_a2_p, &addr_alice, ctx_b_p, &pt_a2_p), 0);
 
-  axc_buf * ct_b1_p = (void *) 0;
-  axc_buf * ct_b2_p = (void *) 0;
+  axc_buf * ct_b1_p = (void *)0;
+  axc_buf * ct_b2_p = (void *)0;
   assert_int_equal(axc_message_encrypt_and_serialize(msg_b1_p, &addr_alice, ctx_b_p, &ct_b1_p), 0);
   assert_int_equal(axc_message_encrypt_and_serialize(msg_b2_p, &addr_alice, ctx_b_p, &ct_b2_p), 0);
 
-  axc_buf * pt_b1_p = (void *) 0;
-  axc_buf * pt_b2_p = (void *) 0;
+  axc_buf * pt_b1_p = (void *)0;
+  axc_buf * pt_b2_p = (void *)0;
   assert_int_equal(axc_message_decrypt_from_serialized(ct_b2_p, &addr_bob, ctx_a_p, &pt_b2_p), 0);
   assert_int_equal(axc_message_decrypt_from_serialized(ct_b1_p, &addr_bob, ctx_a_p, &pt_b1_p), 0);
 
@@ -357,7 +355,7 @@ void test_message_encrypt_decrypt(void **state) {
 }
 
 void test_session_exists_any(void ** state) {
-  (void) state;
+  (void)state;
 
   assert_int_equal(axc_session_exists_initiated(&addr_bob, ctx_a_p), 0);
   assert_int_equal(axc_session_exists_any(addr_bob.name, ctx_a_p), 0);
@@ -369,19 +367,16 @@ void test_session_exists_any(void ** state) {
   assert_int_equal(axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob_p), 0);
   addr_bob.device_id = bundle_bob_p->registration_id;
 
-  assert_int_equal(axc_session_from_bundle(axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
-                                            axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p),
-                                            bundle_bob_p->signed_pre_key_id,
-                                            bundle_bob_p->signed_pre_key_public_serialized_p,
-                                            bundle_bob_p->signed_pre_key_signature_p,
-                                            bundle_bob_p->identity_key_public_serialized_p,
-                                            &addr_bob,
-                                            ctx_a_p),
-                    0);
+  assert_int_equal(axc_session_from_bundle(
+                       axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
+                       axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p), bundle_bob_p->signed_pre_key_id,
+                       bundle_bob_p->signed_pre_key_public_serialized_p, bundle_bob_p->signed_pre_key_signature_p,
+                       bundle_bob_p->identity_key_public_serialized_p, &addr_bob, ctx_a_p),
+                   0);
 
   const char * data = "hello";
-  axc_buf * msg_buf_p = axc_buf_create((uint8_t *) data, strlen(data) + 1);
-  assert_ptr_not_equal(msg_buf_p, (void *) 0);
+  axc_buf * msg_buf_p = axc_buf_create((uint8_t *)data, strlen(data) + 1);
+  assert_ptr_not_equal(msg_buf_p, (void *)0);
 
   axc_buf * ct_buf_p;
   assert_int_equal(axc_message_encrypt_and_serialize(msg_buf_p, &addr_bob, ctx_a_p, &ct_buf_p), 0);
@@ -397,56 +392,53 @@ void test_session_exists_any(void ** state) {
   assert_int_equal(axc_session_exists_initiated(&addr_alice, ctx_b_p), 1);
   assert_int_equal(axc_session_exists_initiated(&addr_alice_42, ctx_b_p), 0);
   assert_int_equal(axc_session_exists_any(addr_alice.name, ctx_b_p), 1);
-
 }
 
-void test_session_from_bundle_and_handle_prekey_message(void **state) {
-  (void) state;
+void test_session_from_bundle_and_handle_prekey_message(void ** state) {
+  (void)state;
 
   axc_address addr_bob = {.name = "bob", .name_len = 3, .device_id = 0};
   assert_int_equal(axc_db_identity_get_local_registration_id(ctx_b_p, (uint32_t *)&(addr_bob.device_id)), 0);
   assert_int_equal(axc_session_exists_initiated(&addr_bob, ctx_a_p), 0);
 
   uint32_t pre_key_id_bob = 10;
-  session_pre_key * pre_key_bob_p = (void *) 0;
-  assert_int_equal(signal_protocol_pre_key_load_key(ctx_b_p->axolotl_store_context_p, &pre_key_bob_p, pre_key_id_bob), 0);
+  session_pre_key * pre_key_bob_p = (void *)0;
+  assert_int_equal(signal_protocol_pre_key_load_key(ctx_b_p->axolotl_store_context_p, &pre_key_bob_p, pre_key_id_bob),
+                   0);
   ec_key_pair * pre_key_pair_p = session_pre_key_get_key_pair(pre_key_bob_p);
   ec_public_key * pre_key_public_p = ec_key_pair_get_public(pre_key_pair_p);
-  axc_buf * pre_key_public_data_p = (void *) 0;
+  axc_buf * pre_key_public_data_p = (void *)0;
   assert_int_equal(ec_public_key_serialize(&pre_key_public_data_p, pre_key_public_p), 0);
 
   uint32_t signed_pre_key_id_bob = 0;
-  session_signed_pre_key * signed_pre_key_bob_p = (void *) 0;
-  assert_int_equal(signal_protocol_signed_pre_key_load_key(ctx_b_p->axolotl_store_context_p, &signed_pre_key_bob_p, signed_pre_key_id_bob), 0);
+  session_signed_pre_key * signed_pre_key_bob_p = (void *)0;
+  assert_int_equal(signal_protocol_signed_pre_key_load_key(ctx_b_p->axolotl_store_context_p, &signed_pre_key_bob_p,
+                                                           signed_pre_key_id_bob),
+                   0);
   ec_key_pair * signed_pre_key_pair_p = session_signed_pre_key_get_key_pair(signed_pre_key_bob_p);
   ec_public_key * signed_pre_key_public_p = ec_key_pair_get_public(signed_pre_key_pair_p);
-  axc_buf * signed_pre_key_public_data_p = (void *) 0;
+  axc_buf * signed_pre_key_public_data_p = (void *)0;
   assert_int_equal(ec_public_key_serialize(&signed_pre_key_public_data_p, signed_pre_key_public_p), 0);
-
 
   axc_buf * signed_pre_key_signature_p = axc_buf_create(session_signed_pre_key_get_signature(signed_pre_key_bob_p),
                                                         session_signed_pre_key_get_signature_len(signed_pre_key_bob_p));
-  assert_ptr_not_equal(signed_pre_key_signature_p, (void *) 0);
+  assert_ptr_not_equal(signed_pre_key_signature_p, (void *)0);
 
-  axc_buf * identity_public_key_bob_p = (void *) 0;
-  axc_buf * identity_private_key_throwaway = (void *) 0;
-  assert_int_equal(axc_db_identity_get_key_pair(&identity_public_key_bob_p, &identity_private_key_throwaway, ctx_b_p), 0);
+  axc_buf * identity_public_key_bob_p = (void *)0;
+  axc_buf * identity_private_key_throwaway = (void *)0;
+  assert_int_equal(axc_db_identity_get_key_pair(&identity_public_key_bob_p, &identity_private_key_throwaway, ctx_b_p),
+                   0);
 
-
-  assert_int_equal(axc_session_from_bundle(pre_key_id_bob,
-                                           pre_key_public_data_p,
-                                           signed_pre_key_id_bob,
-                                           signed_pre_key_public_data_p,
-                                           signed_pre_key_signature_p,
-                                           identity_public_key_bob_p,
-                                           &addr_bob,
-                                           ctx_a_p), 0);
+  assert_int_equal(axc_session_from_bundle(pre_key_id_bob, pre_key_public_data_p, signed_pre_key_id_bob,
+                                           signed_pre_key_public_data_p, signed_pre_key_signature_p,
+                                           identity_public_key_bob_p, &addr_bob, ctx_a_p),
+                   0);
 
   assert_int_equal(axc_session_exists_initiated(&addr_bob, ctx_a_p), 1);
 
   char * test_msg_p = "butter für den buttergott";
-  axc_buf * test_msg_data_p = axc_buf_create((uint8_t *) test_msg_p, strlen(test_msg_p) + 1);
-  axc_buf * test_msg_ct_p = (void *) 0;
+  axc_buf * test_msg_data_p = axc_buf_create((uint8_t *)test_msg_p, strlen(test_msg_p) + 1);
+  axc_buf * test_msg_ct_p = (void *)0;
   assert_int_equal(axc_message_encrypt_and_serialize(test_msg_data_p, &addr_bob, ctx_a_p, &test_msg_ct_p), 0);
 
   size_t pre_keys_count_bob = 0;
@@ -456,10 +448,10 @@ void test_session_from_bundle_and_handle_prekey_message(void **state) {
   assert_int_equal(axc_db_pre_key_get_max_id(ctx_b_p, &max_id_bob), 0);
   assert_int_equal(max_id_bob, AXC_PRE_KEYS_AMOUNT - 1);
 
-  axc_buf * test_msg_decrypted_p = (void *) 0;
+  axc_buf * test_msg_decrypted_p = (void *)0;
   assert_int_equal(axc_pre_key_message_process(test_msg_ct_p, &addr_alice_21, ctx_b_p, &test_msg_decrypted_p), 0);
 
-  assert_string_equal(test_msg_p, (char *) axc_buf_get_data(test_msg_decrypted_p));
+  assert_string_equal(test_msg_p, (char *)axc_buf_get_data(test_msg_decrypted_p));
 
   assert_int_equal(axc_db_pre_key_contains(pre_key_id_bob, ctx_b_p), 0);
   assert_int_equal(axc_db_pre_key_get_count(ctx_b_p, &pre_keys_count_bob), 0);
@@ -469,33 +461,31 @@ void test_session_from_bundle_and_handle_prekey_message(void **state) {
 }
 
 void test_bundle_collect(void ** state) {
-  (void) state;
+  (void)state;
 
   assert_int_equal(axc_install(ctx_global_p), 0);
 
   axc_bundle * bundle_p;
   assert_int_equal(axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_global_p, &bundle_p), 0);
-  assert_ptr_not_equal(bundle_p, (void *) 0);
+  assert_ptr_not_equal(bundle_p, (void *)0);
 
   uint32_t reg_id;
   assert_int_equal(axc_get_device_id(ctx_global_p, &reg_id), 0);
   assert_int_equal(bundle_p->registration_id, reg_id);
 
-  assert_ptr_not_equal(bundle_p->pre_keys_head_p, (void *) 0);
+  assert_ptr_not_equal(bundle_p->pre_keys_head_p, (void *)0);
 
   ec_public_key * signed_pre_key_p;
-  assert_ptr_not_equal(bundle_p->signed_pre_key_public_serialized_p, (void *) 0);
-  assert_int_equal(curve_decode_point(&signed_pre_key_p,
-                                      axc_buf_get_data(bundle_p->signed_pre_key_public_serialized_p),
+  assert_ptr_not_equal(bundle_p->signed_pre_key_public_serialized_p, (void *)0);
+  assert_int_equal(curve_decode_point(&signed_pre_key_p, axc_buf_get_data(bundle_p->signed_pre_key_public_serialized_p),
                                       axc_buf_get_len(bundle_p->signed_pre_key_public_serialized_p),
                                       ctx_global_p->axolotl_global_context_p),
                    0);
-  assert_ptr_not_equal(bundle_p->signed_pre_key_signature_p, (void *) 0);
+  assert_ptr_not_equal(bundle_p->signed_pre_key_signature_p, (void *)0);
 
   ec_public_key * identity_key_p;
-  assert_ptr_not_equal(bundle_p->identity_key_public_serialized_p, (void *) 0);
-  assert_int_equal(curve_decode_point(&identity_key_p,
-                                      axc_buf_get_data(bundle_p->identity_key_public_serialized_p),
+  assert_ptr_not_equal(bundle_p->identity_key_public_serialized_p, (void *)0);
+  assert_int_equal(curve_decode_point(&identity_key_p, axc_buf_get_data(bundle_p->identity_key_public_serialized_p),
                                       axc_buf_get_len(bundle_p->identity_key_public_serialized_p),
                                       ctx_global_p->axolotl_global_context_p),
                    0);
@@ -504,7 +494,7 @@ void test_bundle_collect(void ** state) {
 }
 
 void test_session_exists_prekeys(void ** state) {
-  (void) state;
+  (void)state;
 
   axc_bundle * bundle_bob_p;
   assert_int_equal(axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob_p), 0);
@@ -512,21 +502,18 @@ void test_session_exists_prekeys(void ** state) {
   axc_address addr_bob = {.name = "bob", .name_len = 3, .device_id = bundle_bob_p->registration_id};
   assert_int_equal(axc_session_exists_initiated(&addr_bob, ctx_a_p), 0);
 
-  assert_int_equal(axc_session_from_bundle(axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
-                                            axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p),
-                                            bundle_bob_p->signed_pre_key_id,
-                                            bundle_bob_p->signed_pre_key_public_serialized_p,
-                                            bundle_bob_p->signed_pre_key_signature_p,
-                                            bundle_bob_p->identity_key_public_serialized_p,
-                                            &addr_bob,
-                                            ctx_a_p),
-                    0);
+  assert_int_equal(axc_session_from_bundle(
+                       axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
+                       axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p), bundle_bob_p->signed_pre_key_id,
+                       bundle_bob_p->signed_pre_key_public_serialized_p, bundle_bob_p->signed_pre_key_signature_p,
+                       bundle_bob_p->identity_key_public_serialized_p, &addr_bob, ctx_a_p),
+                   0);
 
   assert_int_equal(axc_session_exists_initiated(&addr_bob, ctx_a_p), 1);
 
   const char * data = "hello";
-  axc_buf * msg_buf_p = axc_buf_create((uint8_t *) data, strlen(data) + 1);
-  assert_ptr_not_equal(msg_buf_p, (void *) 0);
+  axc_buf * msg_buf_p = axc_buf_create((uint8_t *)data, strlen(data) + 1);
+  assert_ptr_not_equal(msg_buf_p, (void *)0);
 
   axc_buf * ct_buf_p;
   assert_int_equal(axc_message_encrypt_and_serialize(msg_buf_p, &addr_bob, ctx_a_p, &ct_buf_p), 0);
@@ -550,12 +537,12 @@ void test_session_exists_prekeys(void ** state) {
   axc_buf_free(pt_buf_p);
 
   const char * other_data = "hello 234";
-  msg_buf_p = axc_buf_create((uint8_t *) other_data, strlen(other_data) + 1);
-  assert_ptr_not_equal(msg_buf_p, (void *) 0);
+  msg_buf_p = axc_buf_create((uint8_t *)other_data, strlen(other_data) + 1);
+  assert_ptr_not_equal(msg_buf_p, (void *)0);
 
   assert_int_equal(axc_message_encrypt_and_serialize(msg_buf_p, &addr_bob, ctx_a_p, &ct_buf_p), 0);
   int ret_val = axc_message_decrypt_from_serialized(ct_buf_p, &addr_alice, ctx_b_p, &pt_buf_p);
-  assert_int_not_equal(ret_val, 0); // if no reply was received yet, axolotl keeps sending prekey messages
+  assert_int_not_equal(ret_val, 0);  // if no reply was received yet, axolotl keeps sending prekey messages
   assert_int_equal(axc_pre_key_message_process(ct_buf_p, &addr_alice, ctx_b_p, &pt_buf_p), 0);
   assert_memory_equal(axc_buf_get_data(msg_buf_p), axc_buf_get_data(pt_buf_p), axc_buf_get_len(msg_buf_p));
 
@@ -565,7 +552,7 @@ void test_session_exists_prekeys(void ** state) {
 }
 
 void test_key_load_public_own(void ** state) {
-  (void) state;
+  (void)state;
 
   axc_buf * key_buf_p;
   assert_int_not_equal(axc_key_load_public_own(ctx_global_p, &key_buf_p), 0);
@@ -583,9 +570,8 @@ void test_key_load_public_own(void ** state) {
   assert_memory_equal(axc_buf_get_data(key_buf_p), axc_buf_get_data(db_key_buf_p), axc_buf_get_len(key_buf_p));
 }
 
-
 void test_key_load_public_addr(void ** state) {
-  (void) state;
+  (void)state;
 
   assert_int_equal(axc_session_exists_any("bob", ctx_a_p), 1);
   assert_int_equal(axc_session_exists_initiated(&addr_bob, ctx_a_p), 1);
@@ -599,15 +585,14 @@ void test_key_load_public_addr(void ** state) {
   assert_int_equal(session_record_is_fresh(sr_p), 0);
 
   axc_buf * db_key_buf_p;
-  assert_int_equal(ec_public_key_serialize(&db_key_buf_p, session_state_get_remote_identity_key(session_record_get_state(sr_p))), 0);
+  assert_int_equal(
+      ec_public_key_serialize(&db_key_buf_p, session_state_get_remote_identity_key(session_record_get_state(sr_p))), 0);
   assert_memory_equal(axc_buf_get_data(key_buf_p), axc_buf_get_data(db_key_buf_p), axc_buf_get_len(key_buf_p));
 
   axc_buf_free(key_buf_p);
   axc_buf_free(db_key_buf_p);
   SIGNAL_UNREF(sr_p);
 }
-
-
 
 int main(void) {
   const struct CMUnitTest tests[] = {
@@ -617,7 +602,8 @@ int main(void) {
       cmocka_unit_test_setup_teardown(test_recursive_mutex_unlock, client_setup, client_teardown),
 
       cmocka_unit_test_setup_teardown(test_install_should_generate_necessary_data, client_setup, client_teardown),
-      cmocka_unit_test_setup_teardown(test_install_should_not_do_anything_if_already_initialiased, client_setup, client_teardown),
+      cmocka_unit_test_setup_teardown(test_install_should_not_do_anything_if_already_initialiased, client_setup,
+                                      client_teardown),
       cmocka_unit_test_setup_teardown(test_install_should_reset_if_needed, client_setup, client_teardown),
 
       cmocka_unit_test_setup_teardown(test_message_encrypt_decrypt, client_setup_sessions, client_teardown_two_dbs),
@@ -625,13 +611,13 @@ int main(void) {
       cmocka_unit_test_setup_teardown(test_session_exists_any, client_setup_two_dbs, client_teardown_two_dbs),
       cmocka_unit_test_setup_teardown(test_session_exists_prekeys, client_setup_two_dbs, client_teardown_two_dbs),
 
-      cmocka_unit_test_setup_teardown(test_session_from_bundle_and_handle_prekey_message, client_setup_two_dbs, client_teardown_two_dbs),
+      cmocka_unit_test_setup_teardown(test_session_from_bundle_and_handle_prekey_message, client_setup_two_dbs,
+                                      client_teardown_two_dbs),
 
       cmocka_unit_test_setup_teardown(test_bundle_collect, client_setup, client_teardown),
 
       cmocka_unit_test_setup_teardown(test_key_load_public_own, client_setup, client_teardown),
-      cmocka_unit_test_setup_teardown(test_key_load_public_addr, client_setup_sessions, client_teardown_two_dbs)
-  };
+      cmocka_unit_test_setup_teardown(test_key_load_public_addr, client_setup_sessions, client_teardown_two_dbs)};
 
   return cmocka_run_group_tests(tests, global_setup, global_teardown);
- }
+}

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -4,15 +4,14 @@
  * Author: Richard Bayerle <riba@firemail.cc>
  */
 
-
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <stdio.h> // remove
-#include <string.h> // strlen
-#include <unistd.h> // access
+#include <stdio.h>   // remove
+#include <string.h>  // strlen
+#include <unistd.h>  // access
 
 #include "../src/axc.c"
 #include "../src/axc_store.c"
@@ -21,7 +20,7 @@ sqlite3 * db_p;
 sqlite3_stmt * pstmt_p;
 
 char * db_filename = "test.sqlite";
-char * rand_db_filename = (void *) 0;
+char * rand_db_filename = (void *)0;
 axc_context * ctx_global_p;
 
 signal_protocol_address addr_alice_42 = {.name = "alice", .name_len = 5, .device_id = 42};
@@ -37,26 +36,26 @@ uint8_t bytes_2_len = sizeof(bytes_2);
 
 const int id = 1337;
 
-int db_setup_internal(void **state) {
-  (void) state;
+int db_setup_internal(void ** state) {
+  (void)state;
 
   int rand_int = g_random_int();
   rand_db_filename = g_strdup_printf("test_%d.sqlite", rand_int);
 
-  ctx_global_p = (void *) 0;
+  ctx_global_p = (void *)0;
   assert_int_equal(axc_context_create(&ctx_global_p), 0);
   assert_int_equal(axc_context_set_db_fn(ctx_global_p, rand_db_filename, strlen(rand_db_filename)), 0);
 
-  db_p = (void *) 0;
-  pstmt_p = (void *) 0;
+  db_p = (void *)0;
+  pstmt_p = (void *)0;
 
   return 0;
 }
 
-int db_setup(void **state) {
-  (void) state;
+int db_setup(void ** state) {
+  (void)state;
 
-  db_setup_internal((void *) 0);
+  db_setup_internal((void *)0);
 
   assert_int_equal(axc_db_create(ctx_global_p), 0);
 
@@ -64,8 +63,8 @@ int db_setup(void **state) {
 }
 
 int db_teardown(void ** state) {
-  (void) state;
-  
+  (void)state;
+
   int ret_val = 0;
   ret_val = sqlite3_finalize(pstmt_p);
   if (ret_val) {
@@ -77,8 +76,8 @@ int db_teardown(void ** state) {
     fprintf(stderr, "failed to close not finalized db\n");
   }
 
-  db_p = (void *) 0;
-  pstmt_p = (void *) 0;
+  db_p = (void *)0;
+  pstmt_p = (void *)0;
 
   if (!access(AXC_DB_DEFAULT_FN, F_OK) && remove(AXC_DB_DEFAULT_FN)) {
     perror("failed to remove default db");
@@ -90,17 +89,17 @@ int db_teardown(void ** state) {
   axc_context_destroy_all(ctx_global_p);
 
   g_free(rand_db_filename);
-  rand_db_filename = (void *) 0;
+  rand_db_filename = (void *)0;
 
-  // as the call to remove often fails intentionally as at least one of the two DVs does not exist, don't let cleanup fail the test
+  // as the call to remove often fails intentionally as at least one of the two DVs does not exist, don't let cleanup
+  // fail the test
   return 0;
 }
 
+void test_db_conn_open_should_create_db_default_filename(void ** state) {
+  (void)state;
 
-void test_db_conn_open_should_create_db_default_filename(void **state) {
-  (void) state;
-
-  axc_context * ctx_p = (void *) 0;
+  axc_context * ctx_p = (void *)0;
   assert_int_equal(axc_context_create(&ctx_p), 0);
 
   assert_int_equal(db_conn_open(&db_p, &pstmt_p, "", ctx_p), 0);
@@ -109,31 +108,31 @@ void test_db_conn_open_should_create_db_default_filename(void **state) {
   axc_context_destroy_all(ctx_p);
 }
 
-void test_db_conn_open_should_create_db(void **state) {
-  (void) state;
+void test_db_conn_open_should_create_db(void ** state) {
+  (void)state;
 
   assert_int_equal(db_conn_open(&db_p, &pstmt_p, "", ctx_global_p), 0);
   assert_int_not_equal(db_p, 0);
   assert_int_equal(access(ctx_global_p->db_filename, F_OK), 0);
 }
 
-void test_db_conn_open_should_prepare_statement(void **state) {
-  (void) state;
+void test_db_conn_open_should_prepare_statement(void ** state) {
+  (void)state;
 
   const char * stmt = "VACUUM;";
   assert_int_equal(db_conn_open(&db_p, &pstmt_p, stmt, ctx_global_p), 0);
-  assert_int_not_equal(pstmt_p, (void *) 0);
+  assert_int_not_equal(pstmt_p, (void *)0);
 }
 
-void test_db_conn_open_should_fail_on_null_pointer(void **state) {
-  (void) state;
+void test_db_conn_open_should_fail_on_null_pointer(void ** state) {
+  (void)state;
 
-  assert_int_not_equal(db_conn_open(&db_p, &pstmt_p, (void *) 0, ctx_global_p), 0);
-  assert_int_equal(pstmt_p, (void *) 0);
+  assert_int_not_equal(db_conn_open(&db_p, &pstmt_p, (void *)0, ctx_global_p), 0);
+  assert_int_equal(pstmt_p, (void *)0);
 }
 
-void test_db_exec_single_change_should_only_succeed_on_correct_number_of_changes(void **state) {
-  (void) state;
+void test_db_exec_single_change_should_only_succeed_on_correct_number_of_changes(void ** state) {
+  (void)state;
 
   const char * stmt1 = "CREATE TABLE test(id INTEGER);";
   const char * stmt2 = "INSERT INTO test VALUES (1)";
@@ -144,8 +143,8 @@ void test_db_exec_single_change_should_only_succeed_on_correct_number_of_changes
   assert_int_equal(db_exec_single_change(db_p, pstmt_p, ctx_global_p), 0);
 }
 
-void test_db_exec_quick_should_exec(void **state) {
-  (void) state;
+void test_db_exec_quick_should_exec(void ** state) {
+  (void)state;
 
   const char * stmt1 = "CREATE TABLE test(id INTEGER);";
   const char * stmt2 = "INSERT INTO test VALUES (1)";
@@ -153,13 +152,13 @@ void test_db_exec_quick_should_exec(void **state) {
   db_exec_quick(stmt1, ctx_global_p);
   db_exec_quick(stmt2, ctx_global_p);
 
-  const char * stmt3 ="SELECT * FROM test;";
+  const char * stmt3 = "SELECT * FROM test;";
   assert_int_equal(db_conn_open(&db_p, &pstmt_p, stmt3, ctx_global_p), 0);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
 }
 
-void test_db_create_should_create_necessary_tables(void **state) {
-  (void) state;
+void test_db_create_should_create_necessary_tables(void ** state) {
+  (void)state;
 
   char * stmt = "PRAGMA table_info(session_store);";
 
@@ -190,7 +189,7 @@ void test_db_create_should_create_necessary_tables(void **state) {
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   stmt = "PRAGMA table_info(pre_key_store);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_string_equal(sqlite3_column_text(pstmt_p, 1), "id");
@@ -208,7 +207,7 @@ void test_db_create_should_create_necessary_tables(void **state) {
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   stmt = "PRAGMA table_info(signed_pre_key_store);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_string_equal(sqlite3_column_text(pstmt_p, 1), "id");
@@ -226,7 +225,7 @@ void test_db_create_should_create_necessary_tables(void **state) {
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   stmt = "PRAGMA table_info(identity_key_store);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_string_equal(sqlite3_column_text(pstmt_p, 1), "name");
@@ -248,7 +247,7 @@ void test_db_create_should_create_necessary_tables(void **state) {
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   stmt = "PRAGMA table_info(settings);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_string_equal(sqlite3_column_text(pstmt_p, 1), "name");
@@ -261,8 +260,8 @@ void test_db_create_should_create_necessary_tables(void **state) {
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 }
 
-void test_db_destroy_should_drop_all_tables(void **state) {
-  (void) state;
+void test_db_destroy_should_drop_all_tables(void ** state) {
+  (void)state;
 
   char * stmt = "PRAGMA table_info(session_store);";
 
@@ -273,31 +272,31 @@ void test_db_destroy_should_drop_all_tables(void **state) {
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 
   stmt = "PRAGMA table_info(pre_key_store);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   stmt = "PRAGMA table_info(signed_pre_key_store);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   stmt = "PRAGMA table_info(identity_key_store);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   stmt = "PRAGMA table_info(settings);";
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 }
 
-void test_db_property_set_should_set_property_correctly(void **state) {
-  (void) state;
+void test_db_property_set_should_set_property_correctly(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_property_set("test", 1337, ctx_global_p), 0);
 
@@ -307,8 +306,8 @@ void test_db_property_set_should_set_property_correctly(void **state) {
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 }
 
-void test_db_property_get_should_get_correctly(void **state) {
-  (void) state;
+void test_db_property_get_should_get_correctly(void ** state) {
+  (void)state;
 
   const char * prop_name = "test";
   const int prop_val = 1337;
@@ -320,15 +319,15 @@ void test_db_property_get_should_get_correctly(void **state) {
   assert_int_equal(result, prop_val);
 }
 
-void test_db_property_get_should_fail_on_no_results(void **state) {
-  (void) state;
+void test_db_property_get_should_fail_on_no_results(void ** state) {
+  (void)state;
 
   int result = 0;
   assert_int_not_equal(axc_db_property_get("test", &result, ctx_global_p), 0);
 }
 
-void test_db_init_status_set_should_work(void **state) {
-  (void) state;
+void test_db_init_status_set_should_work(void ** state) {
+  (void)state;
 
   const int val = 1337;
 
@@ -339,8 +338,8 @@ void test_db_init_status_set_should_work(void **state) {
   assert_int_equal(result, val);
 }
 
-void test_db_init_status_get_should_work(void **state) {
-  (void) state;
+void test_db_init_status_get_should_work(void ** state) {
+  (void)state;
 
   const int val = 1337;
   assert_int_equal(axc_db_init_status_set(val, ctx_global_p), 0);
@@ -350,12 +349,14 @@ void test_db_init_status_get_should_work(void **state) {
   assert_int_equal(result, val);
 }
 
-void test_db_session_store_should_work(void **state) {
-  (void) state;
+void test_db_session_store_should_work(void ** state) {
+  (void)state;
 
-  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *) 0, 0, ctx_global_p), 0);
+  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *)0, 0, ctx_global_p), 0);
 
-  assert_int_equal(db_conn_open(&db_p, &pstmt_p, "SELECT * FROM session_store WHERE name='alice' AND device_id IS 42;", ctx_global_p), 0);
+  assert_int_equal(db_conn_open(&db_p, &pstmt_p, "SELECT * FROM session_store WHERE name='alice' AND device_id IS 42;",
+                                ctx_global_p),
+                   0);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_string_equal(sqlite3_column_text(pstmt_p, 0), addr_alice_42.name);
   assert_int_equal(sqlite3_column_int(pstmt_p, 1), strlen(addr_alice_42.name));
@@ -366,48 +367,50 @@ void test_db_session_store_should_work(void **state) {
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 }
 
-void test_db_session_load_should_find_session(void **state) {
-  (void) state;
+void test_db_session_load_should_find_session(void ** state) {
+  (void)state;
 
-  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *) 0, 0, ctx_global_p), 0);
+  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *)0, 0, ctx_global_p), 0);
 
-  signal_buffer * buf = (void *) 0;
-  assert_int_equal(axc_db_session_load(&buf, (void *) 0, &addr_alice_42, ctx_global_p), 1);
+  signal_buffer * buf = (void *)0;
+  assert_int_equal(axc_db_session_load(&buf, (void *)0, &addr_alice_42, ctx_global_p), 1);
   assert_memory_equal(signal_buffer_data(buf), bytes_1, bytes_1_len);
   assert_int_equal(signal_buffer_len(buf), bytes_1_len);
 }
 
-void test_db_session_load_should_not_find_session(void **state) {
-  (void) state;
+void test_db_session_load_should_not_find_session(void ** state) {
+  (void)state;
 
-  signal_buffer * buf = (void *) 0;
-  assert_int_equal(axc_db_session_load(&buf, (void *) 0, &addr_alice_42, ctx_global_p), 0);
+  signal_buffer * buf = (void *)0;
+  assert_int_equal(axc_db_session_load(&buf, (void *)0, &addr_alice_42, ctx_global_p), 0);
 }
 
-void test_db_session_get_sub_device_sessions_should_find_and_return_correct_number(void **state) {
-  (void) state;
+void test_db_session_get_sub_device_sessions_should_find_and_return_correct_number(void ** state) {
+  (void)state;
 
-  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *) 0, 0, ctx_global_p), 0);
-  assert_int_equal(axc_db_session_store(&addr_alice_21, bytes_2, bytes_2_len, (void *) 0, 0, ctx_global_p), 0);
+  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *)0, 0, ctx_global_p), 0);
+  assert_int_equal(axc_db_session_store(&addr_alice_21, bytes_2, bytes_2_len, (void *)0, 0, ctx_global_p), 0);
 
-  signal_int_list * list_a = (void *) 0;
-  assert_int_equal(axc_db_session_get_sub_device_sessions(&list_a, addr_alice_42.name, addr_alice_42.name_len, ctx_global_p), 2);
+  signal_int_list * list_a = (void *)0;
+  assert_int_equal(
+      axc_db_session_get_sub_device_sessions(&list_a, addr_alice_42.name, addr_alice_42.name_len, ctx_global_p), 2);
 
-  signal_int_list * list_b = (void *) 0;
-  assert_int_equal(axc_db_session_get_sub_device_sessions(&list_b, addr_bob_12.name, addr_bob_12.name_len, ctx_global_p), 0);
+  signal_int_list * list_b = (void *)0;
+  assert_int_equal(
+      axc_db_session_get_sub_device_sessions(&list_b, addr_bob_12.name, addr_bob_12.name_len, ctx_global_p), 0);
 
   assert_int_equal(signal_int_list_size(list_a), 2);
   assert_int_equal(signal_int_list_size(list_b), 0);
 }
 
 void test_db_session_contains_should_return_correct_values(void ** state) {
-  (void) state;
+  (void)state;
 
   char * a_db_filename = "a.sqlite";
   char * b_db_filename = "b.sqlite";
 
-  axc_context * ctx_a_p = (void *) 0;
-  axc_context * ctx_b_p = (void *) 0;
+  axc_context * ctx_a_p = (void *)0;
+  axc_context * ctx_b_p = (void *)0;
 
   signal_protocol_address addr_alice = {.name = "alice", .name_len = 5, .device_id = 0};
   axc_address addr_bob = {.name = "bob", .name_len = 3, .device_id = 0};
@@ -431,19 +434,16 @@ void test_db_session_contains_should_return_correct_values(void ** state) {
   assert_int_equal(axc_bundle_collect(AXC_PRE_KEYS_AMOUNT, ctx_b_p, &bundle_bob_p), 0);
   addr_bob.device_id = bundle_bob_p->registration_id;
 
-  assert_int_equal(axc_session_from_bundle(axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
-                                            axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p),
-                                            bundle_bob_p->signed_pre_key_id,
-                                            bundle_bob_p->signed_pre_key_public_serialized_p,
-                                            bundle_bob_p->signed_pre_key_signature_p,
-                                            bundle_bob_p->identity_key_public_serialized_p,
-                                            &addr_bob,
-                                            ctx_a_p),
-                    0);
+  assert_int_equal(axc_session_from_bundle(
+                       axc_buf_list_item_get_id(bundle_bob_p->pre_keys_head_p),
+                       axc_buf_list_item_get_buf(bundle_bob_p->pre_keys_head_p), bundle_bob_p->signed_pre_key_id,
+                       bundle_bob_p->signed_pre_key_public_serialized_p, bundle_bob_p->signed_pre_key_signature_p,
+                       bundle_bob_p->identity_key_public_serialized_p, &addr_bob, ctx_a_p),
+                   0);
 
   const char * data = "hello";
   axc_buf * msg_buf_p = axc_buf_create((uint8_t *)data, strlen(data) + 1);
-  assert_ptr_not_equal(msg_buf_p, (void *) 0);
+  assert_ptr_not_equal(msg_buf_p, (void *)0);
 
   axc_buf * ct_buf_p;
   assert_int_equal(axc_message_encrypt_and_serialize(msg_buf_p, &addr_bob, ctx_a_p, &ct_buf_p), 0);
@@ -470,30 +470,31 @@ void test_db_session_contains_should_return_correct_values(void ** state) {
   remove(b_db_filename);
 }
 
-void test_db_session_delete_should_return_correct_values(void **state) {
-  (void) state;
+void test_db_session_delete_should_return_correct_values(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_session_delete(&addr_alice_21, ctx_global_p), 0);
-  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *) 0, 0, ctx_global_p), 0);
+  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *)0, 0, ctx_global_p), 0);
   assert_int_equal(axc_db_session_delete(&addr_alice_42, ctx_global_p), 1);
 }
 
-void test_db_session_delete_all_should_return_correct_values(void **state) {
-  (void) state;
+void test_db_session_delete_all_should_return_correct_values(void ** state) {
+  (void)state;
 
-  signal_int_list * sessions = (void *) 0;
+  signal_int_list * sessions = (void *)0;
 
-  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *) 0, 0, ctx_global_p), 0);
-  assert_int_equal(axc_db_session_store(&addr_alice_21, bytes_2, bytes_2_len, (void *) 0, 0, ctx_global_p), 0);
-  assert_int_equal(axc_db_session_get_sub_device_sessions(&sessions, addr_alice_42.name, addr_alice_42.name_len, ctx_global_p), 2);
+  assert_int_equal(axc_db_session_store(&addr_alice_42, bytes_1, bytes_1_len, (void *)0, 0, ctx_global_p), 0);
+  assert_int_equal(axc_db_session_store(&addr_alice_21, bytes_2, bytes_2_len, (void *)0, 0, ctx_global_p), 0);
+  assert_int_equal(
+      axc_db_session_get_sub_device_sessions(&sessions, addr_alice_42.name, addr_alice_42.name_len, ctx_global_p), 2);
 
   assert_int_equal(axc_db_session_delete_all(addr_alice_42.name, addr_alice_42.name_len, ctx_global_p), 2);
-  assert_int_equal(axc_db_session_get_sub_device_sessions(&sessions, addr_alice_42.name, addr_alice_42.name_len, ctx_global_p), 0);
+  assert_int_equal(
+      axc_db_session_get_sub_device_sessions(&sessions, addr_alice_42.name, addr_alice_42.name_len, ctx_global_p), 0);
 }
 
-
-void test_db_pre_key_store_should_work(void **state) {
-  (void) state;
+void test_db_pre_key_store_should_work(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_pre_key_store(1337, bytes_1, bytes_1_len, ctx_global_p), 0);
 
@@ -506,28 +507,28 @@ void test_db_pre_key_store_should_work(void **state) {
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 }
 
-void test_db_pre_key_load_should_return_correct_values_and_key(void **state) {
-  (void) state;
+void test_db_pre_key_load_should_return_correct_values_and_key(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_pre_key_store(id, bytes_1, bytes_1_len, ctx_global_p), 0);
 
-  signal_buffer * buf = (void *) 0;
+  signal_buffer * buf = (void *)0;
   assert_int_equal(axc_db_pre_key_load(&buf, id, ctx_global_p), SG_SUCCESS);
   assert_memory_equal(signal_buffer_data(buf), bytes_1, bytes_1_len);
 
   assert_int_equal(axc_db_pre_key_load(&buf, id + 1, ctx_global_p), SG_ERR_INVALID_KEY_ID);
 }
 
-void test_db_pre_key_contains_should_return_correct_values(void **state) {
-  (void) state;
+void test_db_pre_key_contains_should_return_correct_values(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_pre_key_store(id, bytes_1, bytes_1_len, ctx_global_p), 0);
   assert_int_equal(axc_db_pre_key_contains(id, ctx_global_p), 1);
   assert_int_equal(axc_db_pre_key_contains(id + 1, ctx_global_p), 0);
 }
 
-void test_db_pre_key_remove(void **state) {
-  (void) state;
+void test_db_pre_key_remove(void ** state) {
+  (void)state;
 
   assert_int_not_equal(axc_db_pre_key_remove(id, ctx_global_p), 0);
   assert_int_equal(axc_db_pre_key_store(id, bytes_1, bytes_1_len, ctx_global_p), 0);
@@ -535,21 +536,23 @@ void test_db_pre_key_remove(void **state) {
   assert_int_equal(axc_db_pre_key_contains(id, ctx_global_p), 0);
 }
 
-void test_db_pre_key_store_list(void **state) {
-  (void) state;
+void test_db_pre_key_store_list(void ** state) {
+  (void)state;
 
   const int pre_key_num = 5;
   char stmt[100];
 
-  axc_context * ctx_p = (void *) 0;
+  axc_context * ctx_p = (void *)0;
   assert_int_equal(axc_context_create(&ctx_p), 0);
   assert_int_equal(axc_context_set_db_fn(ctx_p, ctx_global_p->db_filename, strlen(ctx_global_p->db_filename)), 0);
 
   assert_int_equal(axc_init(ctx_p), 0);
 
-  signal_protocol_key_helper_pre_key_list_node * pre_keys_head_p = (void *) 0;
+  signal_protocol_key_helper_pre_key_list_node * pre_keys_head_p = (void *)0;
   // for some reason, key IDs is not inclusive and starts at +1!
-  assert_int_equal(signal_protocol_key_helper_generate_pre_keys(&pre_keys_head_p, 0, pre_key_num, ctx_p->axolotl_global_context_p), 0);
+  assert_int_equal(
+      signal_protocol_key_helper_generate_pre_keys(&pre_keys_head_p, 0, pre_key_num, ctx_p->axolotl_global_context_p),
+      0);
   assert_int_equal(axc_db_pre_key_store_list(pre_keys_head_p, ctx_p), 0);
 
   assert_int_not_equal(sprintf(stmt, "SELECT count(*) FROM pre_key_store;"), 0);
@@ -559,14 +562,14 @@ void test_db_pre_key_store_list(void **state) {
   assert_int_equal(sqlite3_finalize(pstmt_p), SQLITE_OK);
 
   session_pre_key * pre_key_p = signal_protocol_key_helper_key_list_element(pre_keys_head_p);
-  assert_ptr_not_equal(pre_key_p, (void *) 0);
+  assert_ptr_not_equal(pre_key_p, (void *)0);
 
-  signal_buffer * key_buf_p = (void *) 0;
+  signal_buffer * key_buf_p = (void *)0;
   assert_int_equal(session_pre_key_serialize(&key_buf_p, pre_key_p), 0);
 
-
-  assert_int_not_equal(sprintf(stmt, "SELECT * FROM pre_key_store WHERE id IS %i;", session_pre_key_get_id(pre_key_p)), 0);
-  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *) 0), SQLITE_OK);
+  assert_int_not_equal(sprintf(stmt, "SELECT * FROM pre_key_store WHERE id IS %i;", session_pre_key_get_id(pre_key_p)),
+                       0);
+  assert_int_equal(sqlite3_prepare_v2(db_p, stmt, -1, &pstmt_p, (void *)0), SQLITE_OK);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_int_equal(sqlite3_column_int(pstmt_p, 0), session_pre_key_get_id(pre_key_p));
   assert_memory_equal(sqlite3_column_blob(pstmt_p, 1), signal_buffer_data(key_buf_p), signal_buffer_len(key_buf_p));
@@ -574,23 +577,25 @@ void test_db_pre_key_store_list(void **state) {
 }
 
 void test_db_pre_key_get_list(void ** state) {
-  (void) state;
+  (void)state;
 
   assert_int_equal(axc_init(ctx_global_p), 0);
   assert_int_equal(axc_install(ctx_global_p), 0);
 
-  axc_buf_list_item * head_p = (void *) 0;
+  axc_buf_list_item * head_p = (void *)0;
   assert_int_equal(axc_db_pre_key_get_list(AXC_PRE_KEYS_AMOUNT, ctx_global_p, &head_p), 0);
-  assert_ptr_not_equal(head_p, (void *) 0);
+  assert_ptr_not_equal(head_p, (void *)0);
 
   axc_buf_list_item * curr = head_p;
   int count = 0;
-  ec_public_key * pre_key_public_p = (void *) 0;
-  axc_buf * buf_p = (void *) 0;
+  ec_public_key * pre_key_public_p = (void *)0;
+  axc_buf * buf_p = (void *)0;
   while (curr) {
     count++;
     buf_p = axc_buf_list_item_get_buf(curr);
-    assert_int_equal(curve_decode_point(&pre_key_public_p, axc_buf_get_data(buf_p), axc_buf_get_len(buf_p), ctx_global_p->axolotl_global_context_p), 0);
+    assert_int_equal(curve_decode_point(&pre_key_public_p, axc_buf_get_data(buf_p), axc_buf_get_len(buf_p),
+                                        ctx_global_p->axolotl_global_context_p),
+                     0);
     SIGNAL_UNREF(pre_key_public_p);
     curr = curr->next_p;
   }
@@ -601,22 +606,23 @@ void test_db_pre_key_get_list(void ** state) {
 }
 
 void test_db_pre_key_get_max_id(void ** state) {
-  (void) state;
+  (void)state;
 
   assert_int_equal(axc_init(ctx_global_p), 0);
   assert_int_equal(axc_install(ctx_global_p), 0);
 
   uint32_t id = 10;
   assert_int_equal(axc_db_pre_key_get_max_id(ctx_global_p, &id), 0);
-  assert_int_equal(id, AXC_PRE_KEYS_AMOUNT - 1); // ids start with 0
+  assert_int_equal(id, AXC_PRE_KEYS_AMOUNT - 1);  // ids start with 0
 }
 
-void test_db_signed_pre_key_store_should_work(void **state) {
-  (void) state;
+void test_db_signed_pre_key_store_should_work(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_signed_pre_key_store(1337, bytes_1, bytes_1_len, ctx_global_p), 0);
 
-  assert_int_equal(db_conn_open(&db_p, &pstmt_p, "SELECT * FROM signed_pre_key_store WHERE id IS 1337;", ctx_global_p), 0);
+  assert_int_equal(db_conn_open(&db_p, &pstmt_p, "SELECT * FROM signed_pre_key_store WHERE id IS 1337;", ctx_global_p),
+                   0);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_ROW);
   assert_int_equal(sqlite3_column_int(pstmt_p, 0), 1337);
   assert_memory_equal(sqlite3_column_blob(pstmt_p, 1), bytes_1, bytes_1_len);
@@ -625,28 +631,28 @@ void test_db_signed_pre_key_store_should_work(void **state) {
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 }
 
-void test_db_signed_pre_key_load_should_return_correct_values_and_key(void **state) {
-  (void) state;
+void test_db_signed_pre_key_load_should_return_correct_values_and_key(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_signed_pre_key_store(id, bytes_1, bytes_1_len, ctx_global_p), 0);
 
-  signal_buffer * buf = (void *) 0;
+  signal_buffer * buf = (void *)0;
   assert_int_equal(axc_db_signed_pre_key_load(&buf, id, ctx_global_p), SG_SUCCESS);
   assert_memory_equal(signal_buffer_data(buf), bytes_1, bytes_1_len);
 
   assert_int_equal(axc_db_signed_pre_key_load(&buf, id + 1, ctx_global_p), SG_ERR_INVALID_KEY_ID);
 }
 
-void test_db_signed_pre_key_contains_should_return_correct_values(void **state) {
-  (void) state;
+void test_db_signed_pre_key_contains_should_return_correct_values(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_signed_pre_key_store(id, bytes_1, bytes_1_len, ctx_global_p), 0);
   assert_int_equal(axc_db_signed_pre_key_contains(id, ctx_global_p), 1);
   assert_int_equal(axc_db_signed_pre_key_contains(id + 1, ctx_global_p), 0);
 }
 
-void test_db_signed_pre_key_remove(void **state) {
-  (void) state;
+void test_db_signed_pre_key_remove(void ** state) {
+  (void)state;
 
   assert_int_not_equal(axc_db_signed_pre_key_remove(id, ctx_global_p), 0);
   assert_int_equal(axc_db_signed_pre_key_store(id, bytes_1, bytes_1_len, ctx_global_p), 0);
@@ -654,32 +660,35 @@ void test_db_signed_pre_key_remove(void **state) {
   assert_int_equal(axc_db_signed_pre_key_contains(id, ctx_global_p), 0);
 }
 
-void test_db_identity_set_and_get_key_pair(void **state) {
-  (void) state;
+void test_db_identity_set_and_get_key_pair(void ** state) {
+  (void)state;
 
-  axc_context * ctx_p = (void *) 0;
+  axc_context * ctx_p = (void *)0;
   assert_int_equal(axc_context_create(&ctx_p), 0);
   assert_int_equal(axc_context_set_db_fn(ctx_p, ctx_global_p->db_filename, strlen(ctx_global_p->db_filename)), 0);
   assert_int_equal(axc_init(ctx_p), 0);
 
-  ratchet_identity_key_pair * identity_key_pair_p = (void *) 0;
-  assert_int_equal(signal_protocol_key_helper_generate_identity_key_pair(&identity_key_pair_p, ctx_p->axolotl_global_context_p), 0);
+  ratchet_identity_key_pair * identity_key_pair_p = (void *)0;
+  assert_int_equal(
+      signal_protocol_key_helper_generate_identity_key_pair(&identity_key_pair_p, ctx_p->axolotl_global_context_p), 0);
 
   assert_int_equal(axc_db_identity_set_key_pair(identity_key_pair_p, ctx_p), 0);
 
-  signal_buffer * pubkey_saved_p = (void *) 0;
-  signal_buffer * privkey_saved_p = (void *) 0;
+  signal_buffer * pubkey_saved_p = (void *)0;
+  signal_buffer * privkey_saved_p = (void *)0;
   assert_int_equal(axc_db_identity_get_key_pair(&pubkey_saved_p, &privkey_saved_p, ctx_p), 0);
 
-  signal_buffer * pubkey_orig_p = (void *) 0;
-  signal_buffer * privkey_orig_p = (void *) 0;
-  assert_int_equal(ec_public_key_serialize(&pubkey_orig_p,
-      ratchet_identity_key_pair_get_public(identity_key_pair_p)), 0);
-  assert_memory_equal(signal_buffer_data(pubkey_orig_p), signal_buffer_data(pubkey_saved_p), signal_buffer_len(pubkey_saved_p));
+  signal_buffer * pubkey_orig_p = (void *)0;
+  signal_buffer * privkey_orig_p = (void *)0;
+  assert_int_equal(ec_public_key_serialize(&pubkey_orig_p, ratchet_identity_key_pair_get_public(identity_key_pair_p)),
+                   0);
+  assert_memory_equal(signal_buffer_data(pubkey_orig_p), signal_buffer_data(pubkey_saved_p),
+                      signal_buffer_len(pubkey_saved_p));
 
-  assert_int_equal(ec_private_key_serialize(&privkey_orig_p,
-      ratchet_identity_key_pair_get_private(identity_key_pair_p)), 0);
-  assert_memory_equal(signal_buffer_data(privkey_orig_p), signal_buffer_data(privkey_saved_p), signal_buffer_len(privkey_saved_p));
+  assert_int_equal(
+      ec_private_key_serialize(&privkey_orig_p, ratchet_identity_key_pair_get_private(identity_key_pair_p)), 0);
+  assert_memory_equal(signal_buffer_data(privkey_orig_p), signal_buffer_data(privkey_saved_p),
+                      signal_buffer_len(privkey_saved_p));
 
   signal_buffer_free(pubkey_orig_p);
   signal_buffer_free(pubkey_saved_p);
@@ -688,11 +697,11 @@ void test_db_identity_set_and_get_key_pair(void **state) {
 }
 
 void test_db_identity_get_key_pair_keys_not_found(void ** state) {
-  (void) state;
+  (void)state;
 
-  assert_int_equal(axc_db_identity_get_key_pair((void * ) 0, (void *) 0, ctx_global_p), SG_ERR_INVALID_KEY_ID);
+  assert_int_equal(axc_db_identity_get_key_pair((void *)0, (void *)0, ctx_global_p), SG_ERR_INVALID_KEY_ID);
 
-  axc_context * ctx_p = (void *) 0;
+  axc_context * ctx_p = (void *)0;
   assert_int_equal(axc_context_create(&ctx_p), 0);
   assert_int_equal(axc_context_set_db_fn(ctx_p, db_filename, strlen(db_filename)), 0);
   assert_int_equal(axc_init(ctx_p), 0);
@@ -703,11 +712,11 @@ void test_db_identity_get_key_pair_keys_not_found(void ** state) {
   assert_int_equal(db_conn_open(&db_p, &pstmt_p, stmt, ctx_p), 0);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 
-  assert_int_equal(axc_db_identity_get_key_pair((void *) 0, (void *) 0, ctx_p), SG_ERR_INVALID_KEY_ID);
+  assert_int_equal(axc_db_identity_get_key_pair((void *)0, (void *)0, ctx_p), SG_ERR_INVALID_KEY_ID);
 }
 
 void test_db_identity_set_local_registration_id(void ** state) {
-  (void) state;
+  (void)state;
 
   assert_int_equal(axc_db_identity_set_local_registration_id(id, ctx_global_p), 0);
 
@@ -716,8 +725,8 @@ void test_db_identity_set_local_registration_id(void ** state) {
   assert_int_equal(id, result);
 }
 
-void test_db_identity_get_local_registration_id(void **state) {
-  (void) state;
+void test_db_identity_get_local_registration_id(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_identity_set_local_registration_id(id, ctx_global_p), 0);
 
@@ -726,8 +735,8 @@ void test_db_identity_get_local_registration_id(void **state) {
   assert_int_equal(id, result);
 }
 
-void test_db_identity_save(void **state) {
-  (void) state;
+void test_db_identity_save(void ** state) {
+  (void)state;
 
   assert_int_equal(axc_db_identity_save(&addr_alice_21, bytes_1, bytes_1_len, ctx_global_p), 0);
 
@@ -742,7 +751,7 @@ void test_db_identity_save(void **state) {
 
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
 
-  assert_int_equal(axc_db_identity_save(&addr_alice_21, (void *) 0, 0, ctx_global_p), 0);
+  assert_int_equal(axc_db_identity_save(&addr_alice_21, (void *)0, 0, ctx_global_p), 0);
 
   assert_int_equal(sqlite3_reset(pstmt_p), SQLITE_OK);
   assert_int_equal(sqlite3_step(pstmt_p), SQLITE_DONE);
@@ -753,64 +762,69 @@ void test_db_identity_is_trusted(void **state) {
   (void) state;
 
   assert_int_equal(axc_db_identity_save(addr_alice_21.name, 0, bytes_1, bytes_1_len, ctx_global_p), 0);
-  assert_int_equal(axc_db_identity_is_trusted(addr_alice_21.name, addr_alice_21.name_len, bytes_1, bytes_1_len, ctx_global_p), 1);
-  assert_int_equal(axc_db_identity_is_trusted(addr_alice_21.name, addr_alice_21.name_len, bytes_2, bytes_2_len, ctx_global_p), 0);
-  assert_int_equal(axc_db_identity_is_trusted(addr_bob_12.name, addr_bob_12.name_len, bytes_2, bytes_2_len, ctx_global_p), 1);
+  assert_int_equal(axc_db_identity_is_trusted(addr_alice_21.name, addr_alice_21.name_len, bytes_1, bytes_1_len,
+ctx_global_p), 1); assert_int_equal(axc_db_identity_is_trusted(addr_alice_21.name, addr_alice_21.name_len, bytes_2,
+bytes_2_len, ctx_global_p), 0); assert_int_equal(axc_db_identity_is_trusted(addr_bob_12.name, addr_bob_12.name_len,
+bytes_2, bytes_2_len, ctx_global_p), 1);
 }
 */
 
 int main(void) {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_db_conn_open_should_create_db_default_filename, db_setup_internal, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_conn_open_should_create_db, db_setup_internal, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_conn_open_should_prepare_statement, db_setup_internal, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_conn_open_should_fail_on_null_pointer, db_setup_internal, db_teardown),
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test_setup_teardown(test_db_conn_open_should_create_db_default_filename, db_setup_internal,
+                                      db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_conn_open_should_create_db, db_setup_internal, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_conn_open_should_prepare_statement, db_setup_internal, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_conn_open_should_fail_on_null_pointer, db_setup_internal, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_exec_single_change_should_only_succeed_on_correct_number_of_changes, db_setup_internal, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_exec_single_change_should_only_succeed_on_correct_number_of_changes,
+                                      db_setup_internal, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_exec_quick_should_exec, db_setup_internal, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_exec_quick_should_exec, db_setup_internal, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_create_should_create_necessary_tables, db_setup_internal, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_create_should_create_necessary_tables, db_setup_internal, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_destroy_should_drop_all_tables, db_setup_internal, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_destroy_should_drop_all_tables, db_setup_internal, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_property_set_should_set_property_correctly, db_setup, db_teardown),
-        
-        cmocka_unit_test_setup_teardown(test_db_property_get_should_get_correctly, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_property_get_should_fail_on_no_results, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_property_set_should_set_property_correctly, db_setup, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_init_status_set_should_work, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_init_status_get_should_work, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_property_get_should_get_correctly, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_property_get_should_fail_on_no_results, db_setup, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_session_store_should_work, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_session_load_should_find_session, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_session_load_should_not_find_session, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_session_get_sub_device_sessions_should_find_and_return_correct_number, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_session_contains_should_return_correct_values, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_session_delete_should_return_correct_values, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_session_delete_all_should_return_correct_values, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_init_status_set_should_work, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_init_status_get_should_work, db_setup, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_pre_key_store_should_work, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_pre_key_store_list, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_pre_key_get_list, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_pre_key_load_should_return_correct_values_and_key, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_pre_key_contains_should_return_correct_values, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_pre_key_remove, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_pre_key_get_max_id, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_session_store_should_work, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_session_load_should_find_session, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_session_load_should_not_find_session, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_session_get_sub_device_sessions_should_find_and_return_correct_number,
+                                      db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_session_contains_should_return_correct_values, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_session_delete_should_return_correct_values, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_session_delete_all_should_return_correct_values, db_setup, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_signed_pre_key_store_should_work, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_signed_pre_key_load_should_return_correct_values_and_key, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_signed_pre_key_contains_should_return_correct_values, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_signed_pre_key_remove, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_pre_key_store_should_work, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_pre_key_store_list, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_pre_key_get_list, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_pre_key_load_should_return_correct_values_and_key, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_pre_key_contains_should_return_correct_values, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_pre_key_remove, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_pre_key_get_max_id, db_setup, db_teardown),
 
-        cmocka_unit_test_setup_teardown(test_db_identity_set_local_registration_id, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_identity_get_local_registration_id, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_identity_set_and_get_key_pair, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_identity_save, db_setup, db_teardown),
-        //cmocka_unit_test_setup_teardown(test_db_identity_is_trusted, db_setup, db_teardown),
-        cmocka_unit_test_setup_teardown(test_db_identity_get_key_pair_keys_not_found, db_setup, db_teardown)
+      cmocka_unit_test_setup_teardown(test_db_signed_pre_key_store_should_work, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_signed_pre_key_load_should_return_correct_values_and_key, db_setup,
+                                      db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_signed_pre_key_contains_should_return_correct_values, db_setup,
+                                      db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_signed_pre_key_remove, db_setup, db_teardown),
 
-    };
-    return cmocka_run_group_tests(tests, NULL, NULL);
+      cmocka_unit_test_setup_teardown(test_db_identity_set_local_registration_id, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_identity_get_local_registration_id, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_identity_set_and_get_key_pair, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_identity_save, db_setup, db_teardown),
+      // cmocka_unit_test_setup_teardown(test_db_identity_is_trusted, db_setup, db_teardown),
+      cmocka_unit_test_setup_teardown(test_db_identity_get_key_pair_keys_not_found, db_setup, db_teardown)
+
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
 }
-


### PR DESCRIPTION
@gkdr this may not be your favorite clang-format preset/config yet and it the commit where clang-format is mass-applied will need a remake after PR #38 is merged. However, it's probably still in interesting demo and the work outside of config tuning is done (unless you see things missing).

PS: I picked from stock clang-format 14 presets based on a dumb metric: The difference in lines to the original code, like this:
```console
# for i in LLVM GNU Google Chromium Microsoft Mozilla WebKit; do git reset --hard dev >/dev/null ; git ls-files '*.[ch]' | xargs clang-format -i --style="$i" --sort-includes=0; echo "$(git diff -U0 | grep '^[+-]' | wc -l) lines diff with style $i" ; done | sort -n
3651 lines diff with style Google
3775 lines diff with style LLVM
3919 lines diff with style Chromium
4500 lines diff with style Mozilla
7563 lines diff with style WebKit
8033 lines diff with style Microsoft
8401 lines diff with style GNU
```
PS: Don't "try this^^ at home", or at least note the `git reset --hard dev` in the loop before running that command locally :smiley: 
